### PR TITLE
Add travis.yml with Zola build and gh-pages deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: generic
+
+env:
+  global
+    - ZOLA_RELEASES=https://github.com/getzola/zola/releases/download
+    - ZOLA_V=v0.5.1
+    - ARCH=x86_64-unknown-linux-gnu
+
+install:
+  - curl -L ${ZOLA_RELEASES}/${ZOLA_V}/zola-${ZOLA_V}-${ARCH}.tar.gz | tar -xz
+  - ./zola --version
+
+script:
+  - ./zola build
+
+deploy:
+  provider: pages
+  local_dir: public
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN  # Set in the settings page of the repository, as a secure variable
+  keep_history: true
+  on:
+    branch: master


### PR DESCRIPTION
This PR adds a Travis job that downloads v0.5.1 version of Zola from the GitHub releases and uses it to build this site. If the build is run on `master` and it's not a PR, then the results get deployed to gh-pages branch.

For this PR to work:

- Travis builds must be enabled for this repo
- [the GITHUB_TOKEN token (with `public_repo` scope) must be added to Travis settings](https://docs.travis-ci.com/user/environment-variables#defining-variables-in-repository-settings)
- github-pages must be enabled in the settings of this repo

Docs:
- https://docs.travis-ci.com/user/deployment/pages

------

_Depends on #217 ("Remove wasm-network/tweek-rust crate")_