### PR TITLE
Adding SFML bindings

### DIFF
--- a/content/categories/engines/data.toml
+++ b/content/categories/engines/data.toml
@@ -94,3 +94,9 @@ source = "crates"
 [[crates]]
 name = "raylib"
 source = "crates"
+
+[[crates]]
+name = "jeremyletang/rust-sfml"
+author = "jeremyletang"
+source = "crates"
+homepage = "https://github.com/jeremyletang/rust-sfml"


### PR DESCRIPTION
Acknowledge the existence of SFML bindings for rust because SFML is good

SFML is what I made my first game in and I have special memories with it. And its pretty popular so i was surprised to hear that the rust bindings were not already in.