### PR TITLE
Update Zola to v0.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BASE_URL: https://github.com/getzola/zola/releases/download
-      VERS: v0.5.1
+      VERS: v0.9.0
       ARCH: x86_64-unknown-linux-gnu
       # https://github.com/marketplace/actions/github-pages#warning-limitation
       GITHUB_PAT: ${{ secrets.GITHUB_PAT }}

--- a/templates/categories/page.html
+++ b/templates/categories/page.html
@@ -186,7 +186,7 @@ a taxonomy, which isn't completely accurate since it's more like pages with exte
       <div class="three wide column">
       </div>
       <div class="ten wide column">
-        {# display each box of content #} {% set config = load_data(path = page.path ~ "data.toml", format="toml") %} {# dynamic
+        {# display each box of content #} {% set config = load_data(path = "content/" ~ page.path ~ "data.toml", format="toml") %} {# dynamic
         data loaded using the crates.io API #} {% if config.crates %} {% for crate in config.crates %} {{ macros::info(crate=crate)
         }} {% endfor %} {% endif %}
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -109,7 +109,7 @@
             <div class="three wide column"></div>
             <div class="ten wide column">
                 <div class="ui four stackable cards">
-                    {% set categories = get_section(path="categories/_index.md") %} {% for category in categories.pages %} {% set data = load_data(path=category.path
+                    {% set categories = get_section(path="categories/_index.md") %} {% for category in categories.pages %} {% set data = load_data(path="content/" ~ category.path
                     ~ "data.toml") %}
                     <a class="ui card" href="{{category.permalink}}">
                         <div class="content">
@@ -148,7 +148,7 @@
             </div>
             <div class="ten wide column">
                 <div class="ui four stackable cards">
-                    {% set data = load_data(path="games/data.toml") %}
+                    {% set data = load_data(path="content/games/data.toml") %}
                     {% for game in data.games %} 
                         <a class="ui card" href="{{ game.link }}">
                             <img class="ui image" src="{{ game.image }}">
@@ -181,7 +181,7 @@
             <div class="three wide column"></div>
             <div class="ten wide column">
                 <div class="ui four stackable cards">
-                    {% set data = load_data(path="resources/data.toml") %}
+                    {% set data = load_data(path="content/resources/data.toml") %}
                     {% for resource in data.resources %} 
                         <a class="ui card" href="{{ resource.link }}">
                             <div class="content">
@@ -216,7 +216,7 @@
             <div class="three wide column"></div>
             <div class="ten wide column">
                 <div class="ui three cards">
-                    {% set data = load_data(path="contributors/data.toml") %}
+                    {% set data = load_data(path="content/contributors/data.toml") %}
                     {{ macros::contributors(contributors=data.contributors) }} 
                 </div>
             </div>


### PR DESCRIPTION
[From Zola 0.6 changelog](https://github.com/getzola/zola/blob/master/CHANGELOG.md#060-2019-03-25):

> Default directory for `load_data` is now the root of the site instead of the content directory

Fixes #182 (_"Local build doesn't work with latest Zola (0.6)"_)
