### PR TITLE
Sort categories based on name

### DIFF
--- a/content/categories/2drendering/data.toml
+++ b/content/categories/2drendering/data.toml
@@ -1,25 +1,9 @@
 [[crates]]
-name = "piston2d-graphics"
-source = "crates"
-
-[[crates]]
-name = "lyon"
-source = "crates"
-
-[[crates]]
-name = "hex2d"
-source = "crates"
-
-[[crates]]
-name = "elmesque"
-source = "crates"
-
-[[crates]]
 name = "benzene-2d"
 source = "crates"
 
 [[crates]]
-name = "sfml"
+name = "beryllium"
 source = "crates"
 
 [[crates]]
@@ -27,19 +11,7 @@ name = "blit"
 source = "crates"
 
 [[crates]]
-name = "rusttype"
-source = "crates"
-
-[[crates]]
-name = "nuklear-rust"
-source = "crates"
-
-[[crates]]
-name = "image"
-source = "crates"
-
-[[crates]]
-name = "sdl2"
+name = "elmesque"
 source = "crates"
 
 [[crates]]
@@ -47,5 +19,33 @@ name = "fermium"
 source = "crates"
 
 [[crates]]
-name = "beryllium"
+name = "hex2d"
+source = "crates"
+
+[[crates]]
+name = "image"
+source = "crates"
+
+[[crates]]
+name = "lyon"
+source = "crates"
+
+[[crates]]
+name = "nuklear-rust"
+source = "crates"
+
+[[crates]]
+name = "piston2d-graphics"
+source = "crates"
+
+[[crates]]
+name = "rusttype"
+source = "crates"
+
+[[crates]]
+name = "sdl2"
+source = "crates"
+
+[[crates]]
+name = "sfml"
 source = "crates"

--- a/content/categories/3dformatloaders/data.toml
+++ b/content/categories/3dformatloaders/data.toml
@@ -1,5 +1,17 @@
 [[crates]]
+name = "blend"
+source = "crates"
+
+[[crates]]
+name = "collada"
+source = "crates"
+
+[[crates]]
 name = "fbx_direct"
+source = "crates"
+
+[[crates]]
+name = "fbxcel-dom"
 source = "crates"
 
 [[crates]]
@@ -15,21 +27,9 @@ name = "obj-rs"
 source = "crates"
 
 [[crates]]
-name = "wavefront_obj"
-source = "crates"
-
-[[crates]]
 name = "tobj"
 source = "crates"
 
 [[crates]]
-name = "collada"
-source = "crates"
-
-[[crates]]
-name = "fbxcel-dom"
-source = "crates"
-
-[[crates]]
-name = "blend"
+name = "wavefront_obj"
 source = "crates"

--- a/content/categories/3drendering/data.toml
+++ b/content/categories/3drendering/data.toml
@@ -1,5 +1,10 @@
 [[crates]]
-name = "gfx-hal"
+name = "ash"
+source = "crates"
+gitter_url = "https://gitter.im/MaikKlein/ash"
+
+[[crates]]
+name = "euc"
 source = "crates"
 
 [[crates]]
@@ -8,18 +13,16 @@ source = "crates"
 gitter_url = "https://gitter.im/gfx-rs/gfx"
 
 [[crates]]
-name = "luminance"
-source = "crates"
-gitter_url = "https://gitter.im/phaazon/luminance-rs"
-
-[[crates]]
-name = "vulkano"
+name = "gfx-hal"
 source = "crates"
 
 [[crates]]
-name = "ash"
+name = "gl"
 source = "crates"
-gitter_url = "https://gitter.im/MaikKlein/ash"
+
+[[crates]]
+name = "glfw"
+source = "crates"
 
 [[crates]]
 name = "glium"
@@ -32,19 +35,7 @@ source = "crates"
 gitter_url = "https://gitter.im/tomaka/glutin"
 
 [[crates]]
-name = "glfw"
-source = "crates"
-
-[[crates]]
-name = "kiss3d"
-source = "crates"
-
-[[crates]]
-name = "three"
-source = "crates"
-
-[[crates]]
-name = "vk-sync"
+name = "grr"
 source = "crates"
 
 [[crates]]
@@ -52,25 +43,34 @@ name = "hephaestus"
 source = "crates"
 
 [[crates]]
+name = "kiss3d"
+source = "crates"
+
+[[crates]]
+name = "luminance"
+source = "crates"
+gitter_url = "https://gitter.im/phaazon/luminance-rs"
+
+[[crates]]
 name = "rendy"
 source = "crates"
 
 [[crates]]
-name = "gl"
+name = "three"
 source = "crates"
 
 [[crates]]
-name="vk-mem"
+name = "vk-mem"
 source = "crates"
 
 [[crates]]
-name="wgpu"
+name = "vk-sync"
 source = "crates"
 
 [[crates]]
-name="euc"
+name = "vulkano"
 source = "crates"
 
 [[crates]]
-name = "grr"
+name = "wgpu"
 source = "crates"

--- a/content/categories/ai/data.toml
+++ b/content/categories/ai/data.toml
@@ -1,5 +1,5 @@
 [[crates]]
-name = "steering"
+name = "aspen"
 source = "crates"
 
 [[crates]]
@@ -8,7 +8,7 @@ source = "crates"
 homepage = "https://github.com/PsichiX/navmesh"
 
 [[crates]]
-name = "aspen"
+name = "pathfinding"
 source = "crates"
 
 [[crates]]
@@ -16,5 +16,5 @@ name = "piston-ai_behavior"
 source = "crates"
 
 [[crates]]
-name = "pathfinding"
+name = "steering"
 source = "crates"

--- a/content/categories/audio/data.toml
+++ b/content/categories/audio/data.toml
@@ -1,37 +1,5 @@
 [[crates]]
-name = "fmod"
-source = "crates"
-
-[[crates]]
-name = "ears"
-source = "crates"
-
-[[crates]]
 name = "alto"
-source = "crates"
-
-[[crates]]
-name = "cpal"
-source = "crates"
-
-[[crates]]
-name = "portmidi"
-source = "crates"
-
-[[crates]]
-name = "lewton"
-source = "crates"
-
-[[crates]]
-name = "vorbis"
-source = "crates"
-
-[[crates]]
-name = "rsoundio"
-source = "crates"
-
-[[crates]]
-name = "rodio"
 source = "crates"
 
 [[crates]]
@@ -43,11 +11,15 @@ name = "claxon"
 source = "crates"
 
 [[crates]]
-name = "hound"
+name = "cpal"
 source = "crates"
 
 [[crates]]
-name = "minimp3"
+name = "ears"
+source = "crates"
+
+[[crates]]
+name = "fmod"
 source = "crates"
 
 [[crates]]
@@ -55,7 +27,23 @@ name = "gme"
 source = "crates"
 
 [[crates]]
+name = "hound"
+source = "crates"
+
+[[crates]]
+name = "lewton"
+source = "crates"
+
+[[crates]]
+name = "minimp3"
+source = "crates"
+
+[[crates]]
 name = "mod_player"
+source = "crates"
+
+[[crates]]
+name = "portmidi"
 source = "crates"
 
 [[crates]]
@@ -63,5 +51,17 @@ name = "rg3d-sound"
 source = "crates"
 
 [[crates]]
+name = "rodio"
+source = "crates"
+
+[[crates]]
+name = "rsoundio"
+source = "crates"
+
+[[crates]]
 name = "sdl2"
+source = "crates"
+
+[[crates]]
+name = "vorbis"
 source = "crates"

--- a/content/categories/ecs/data.toml
+++ b/content/categories/ecs/data.toml
@@ -1,18 +1,9 @@
 [[crates]]
-name = "specs"
-source = "crates"
-gitter_url = "https://gitter.im/slide-rs/specs"
-
-[[crates]]
-name = "ecs"
+name = "calx-ecs"
 source = "crates"
 
 [[crates]]
-name = "recs"
-source = "crates"
-
-[[crates]]
-name = "ecs-rs"
+name = "dces"
 source = "crates"
 
 [[crates]]
@@ -20,8 +11,46 @@ name = "eccles"
 source = "crates"
 
 [[crates]]
+name = "ecs"
+source = "crates"
+
+[[crates]]
+name = "ecs-rs"
+source = "crates"
+
+[[crates]]
 name = "entity_rust"
 source = "crates"
+
+[[crates]]
+name = "froggy"
+source = "crates"
+
+[[crates]]
+name = "legion"
+source = "crates"
+
+[[crates]]
+name = "nitric"
+source = "crates"
+
+[[crates]]
+name = "pyro"
+source = "crates"
+
+[[crates]]
+name = "recs"
+source = "crates"
+
+[[crates]]
+name = "shipyard"
+source = "crates"
+gitter_url = "https://gitter.im/leudz-shipyard/community"
+
+[[crates]]
+name = "specs"
+source = "crates"
+gitter_url = "https://gitter.im/slide-rs/specs"
 
 [[crates]]
 name = "tinyecs"
@@ -30,32 +59,3 @@ source = "crates"
 [[crates]]
 name = "trex"
 source = "crates"
-
-[[crates]]
-name = "calx-ecs"
-source = "crates"
-
-[[crates]]
-name = "nitric"
-source = "crates"
-
-[[crates]]
-name = "froggy"
-source = "crates"
-
-[[crates]]
-name = "pyro"
-source = "crates"
-
-[[crates]]
-name = "dces"
-source = "crates"
-
-[[crates]]
-name = "legion"
-source = "crates"
-
-[[crates]]
-name = "shipyard"
-source = "crates"
-gitter_url = "https://gitter.im/leudz-shipyard/community"

--- a/content/categories/engines/data.toml
+++ b/content/categories/engines/data.toml
@@ -1,23 +1,27 @@
-#crates.io
+[[crates]]
+name = "ChariotEngine/Chariot"
+source = "github"
+
+[[crates]]
+name = "Gigoteur/UnicornConsole"
+source = "github"
+gitter_url = "https://gitter.im/UnicornConsole/Lobby"
+
+[[crates]]
+name = "Hossein-Noroozpour/vulkust"
+source = "github"
+
+[[crates]]
+name = "Siebencorgie/jakar-engine"
+source = "github"
+homepage = "https://gitlab.com/Siebencorgie/jakar-engine"
+
 [[crates]]
 name = "amethyst"
 source = "crates"
 
 [[crates]]
-name = "piston"
-source = "crates"
-
-[[crates]]
-name = "oxygengine"
-source = "crates"
-homepage = "https://github.com/PsichiX/Oxygengine"
-
-[[crates]]
-name = "corange-rs"
-source = "crates"
-
-[[crates]]
-name = "ggez"
+name = "caper"
 source = "crates"
 
 [[crates]]
@@ -25,15 +29,27 @@ name = "coffee"
 source = "crates"
 
 [[crates]]
+name = "corange-rs"
+source = "crates"
+
+[[crates]]
+name = "crayon"
+source = "crates"
+
+[[crates]]
 name = "darkengine"
 source = "crates"
 
 [[crates]]
-name = "turbine"
+name = "gate"
 source = "crates"
 
 [[crates]]
-name = "caper"
+name = "gdnative"
+source = "crates"
+
+[[crates]]
+name = "ggez"
 source = "crates"
 
 [[crates]]
@@ -46,19 +62,16 @@ source = "crates"
 gitter_url = "https://gitter.im/nitro-game-engine/nitro"
 
 [[crates]]
-name = "sdl2"
+name = "oxygengine"
+source = "crates"
+homepage = "https://github.com/PsichiX/Oxygengine"
+
+[[crates]]
+name = "peacock"
 source = "crates"
 
 [[crates]]
-name = "gdnative"
-source = "crates"
-
-[[crates]]
-name = "tetra"
-source = "crates"
-
-[[crates]]
-name = "crayon"
+name = "piston"
 source = "crates"
 
 [[crates]]
@@ -66,42 +79,26 @@ name = "quicksilver"
 source = "crates"
 
 [[crates]]
-name = "gate"
+name = "raylib"
 source = "crates"
-
-[[crates]]
-name = "peacock"
-source = "crates"
-
-#github.com
-[[crates]]
-name = "ChariotEngine/Chariot"
-source = "github"
-
-[[crates]]
-name = "Siebencorgie/jakar-engine"
-source = "github"
-homepage = "https://gitlab.com/Siebencorgie/jakar-engine"
-
-[[crates]]
-name = "Gigoteur/UnicornConsole"
-source = "github"
-gitter_url = "https://gitter.im/UnicornConsole/Lobby"
-
-[[crates]]
-name = "Hossein-Noroozpour/vulkust"
-source = "github"
 
 [[crates]]
 name = "rg3d"
 source = "crates"
 
 [[crates]]
-name = "raylib"
+name = "sdl2"
 source = "crates"
-
 
 [[crates]]
 name = "sfml"
 source = "crates"
-homepage="https://github.com/jeremyletang/rust-sfml"
+homepage = "https://github.com/jeremyletang/rust-sfml"
+
+[[crates]]
+name = "tetra"
+source = "crates"
+
+[[crates]]
+name = "turbine"
+source = "crates"

--- a/content/categories/math/data.toml
+++ b/content/categories/math/data.toml
@@ -1,9 +1,21 @@
 [[crates]]
+name = "I3ck/rust-3d"
+source = "github"
+
+[[crates]]
+name = "bvh"
+source = "crates"
+
+[[crates]]
 name = "cgmath"
 source = "crates"
 
 [[crates]]
-name = "nalgebra"
+name = "dual_quaternion"
+source = "crates"
+
+[[crates]]
+name = "euclid"
 source = "crates"
 
 [[crates]]
@@ -12,11 +24,27 @@ source = "crates"
 gitter_url = "https://gitter.im/euler-rs/Lobby"
 
 [[crates]]
-name = "vek"
+name = "generic-matrix"
 source = "crates"
 
 [[crates]]
-name = "dual_quaternion"
+name = "glam"
+source = "crates"
+
+[[crates]]
+name = "mint"
+source = "crates"
+
+[[crates]]
+name = "nalgebra"
+source = "crates"
+
+[[crates]]
+name = "oxygen_quark"
+source = "crates"
+
+[[crates]]
+name = "palette"
 source = "crates"
 
 [[crates]]
@@ -28,33 +56,5 @@ name = "vecmath"
 source = "crates"
 
 [[crates]]
-name = "palette"
-source = "crates"
-
-[[crates]]
-name = "generic-matrix"
-source = "crates"
-
-[[crates]]
-name = "bvh"
-source = "crates"
-
-[[crates]]
-name = "I3ck/rust-3d"
-source = "github"
-
-[[crates]]
-name = "oxygen_quark"
-source = "crates"
-
-[[crates]]
-name = "euclid"
-source = "crates"
-
-[[crates]]
-name = "mint"
-source = "crates"
-
-[[crates]]
-name = "glam"
+name = "vek"
 source = "crates"

--- a/content/categories/mesh/data.toml
+++ b/content/categories/mesh/data.toml
@@ -1,7 +1,7 @@
 [[crates]]
+name = "huxingyi/meshlite"
+source = "github"
+
+[[crates]]
 name = "meshopt"
 source = "crates"
-
-[[crates]]	
-name = "huxingyi/meshlite"	
-source = "github"

--- a/content/categories/networking/data.toml
+++ b/content/categories/networking/data.toml
@@ -1,11 +1,11 @@
 [[crates]]
+name = "amethyst_network"
+source = "crates"
+
+[[crates]]
 name = "enet"
 source = "crates"
 
 [[crates]]
 name = "laminar"
-source = "crates"
-
-[[crates]]
-name = "amethyst_network"
 source = "crates"

--- a/content/categories/physics/data.toml
+++ b/content/categories/physics/data.toml
@@ -1,21 +1,5 @@
 [[crates]]
-name = "nphysics"
-source = "crates"
-
-[[crates]]
-name = "wrapped2d"
-source = "crates"
-
-[[crates]]
 name = "chipmunk"
-source = "crates"
-
-[[crates]]
-name = "liquidfun"
-source = "crates"
-
-[[crates]]
-name = "ncollide"
 source = "crates"
 
 [[crates]]
@@ -23,11 +7,19 @@ name = "collider"
 source = "crates"
 
 [[crates]]
+name = "liquidfun"
+source = "crates"
+
+[[crates]]
 name = "mgf"
 source = "crates"
 
 [[crates]]
-name = "rhusics"
+name = "ncollide"
+source = "crates"
+
+[[crates]]
+name = "nphysics"
 source = "crates"
 
 [[crates]]
@@ -42,3 +34,11 @@ source = "crates"
 name = "physx"
 source = "crates"
 homepage = "https://github.com/EmbarkStudios/physx-rs"
+
+[[crates]]
+name = "rhusics"
+source = "crates"
+
+[[crates]]
+name = "wrapped2d"
+source = "crates"

--- a/content/categories/scripting/data.toml
+++ b/content/categories/scripting/data.toml
@@ -8,7 +8,7 @@ source = "crates"
 gitter_url = "https://gitter.im/gluon-lang/gluon"
 
 [[crates]]
-name = "rhai"
+name = "hlua"
 source = "crates"
 
 [[crates]]
@@ -16,11 +16,7 @@ name = "ketos"
 source = "crates"
 
 [[crates]]
-name = "hlua"
-source = "crates"
-
-[[crates]]
-name = "rlua"
+name = "lichen"
 source = "crates"
 
 [[crates]]
@@ -28,7 +24,11 @@ name = "luajit"
 source = "crates"
 
 [[crates]]
-name = "lichen"
+name = "rhai"
+source = "crates"
+
+[[crates]]
+name = "rlua"
 source = "crates"
 
 [[crates]]

--- a/content/categories/shader/data.toml
+++ b/content/categories/shader/data.toml
@@ -1,7 +1,7 @@
 [[crates]]
-name = "spirv-reflect"
+name = "include-merkle"
 source = "crates"
 
 [[crates]]
-name = "include-merkle"
+name = "spirv-reflect"
 source = "crates"

--- a/content/categories/tools/data.toml
+++ b/content/categories/tools/data.toml
@@ -1,13 +1,4 @@
 [[crates]]
-name = "modio"
-source = "crates"
-gitter_url = "https://discord.mod.io/"
-
-[[crates]]
-name = "sharecart1000"
-source = "crates"
-
-[[crates]]
 name = "aseprite"
 source = "crates"
 
@@ -16,7 +7,22 @@ name = "ezing"
 source = "crates"
 
 [[crates]]
+name = "huxingyi/dust3d"
+source = "github"
+gitter_url = "https://dust3d.discourse.group/"
+homepage = "https://dust3d.org/"
+
+[[crates]]
+name = "modio"
+source = "crates"
+gitter_url = "https://discord.mod.io/"
+
+[[crates]]
 name = "noise"
+source = "crates"
+
+[[crates]]
+name = "pyxel"
 source = "crates"
 
 [[crates]]
@@ -24,7 +30,7 @@ name = "rusttype"
 source = "crates"
 
 [[crates]]
-name = "pyxel"
+name = "sharecart1000"
 source = "crates"
 
 [[crates]]
@@ -34,9 +40,3 @@ source = "crates"
 [[crates]]
 name = "tiled"
 source = "crates"
-
-[[crates]]
-name = "huxingyi/dust3d"
-source = "github"
-gitter_url = "https://dust3d.discourse.group/"
-homepage = "https://dust3d.org/"

--- a/content/categories/ui/data.toml
+++ b/content/categories/ui/data.toml
@@ -3,15 +3,15 @@ name = "conrod"
 source = "crates"
 
 [[crates]]
-name = "imgui"
-source = "crates"
-
-[[crates]]
 name = "fungui"
 source = "crates"
 
 [[crates]]
-name = "nuklear-rust"
+name = "imgui"
+source = "crates"
+
+[[crates]]
+name = "imgui-ext"
 source = "crates"
 
 [[crates]]
@@ -19,7 +19,7 @@ name = "immi"
 source = "crates"
 
 [[crates]]
-name = "imgui-ext"
+name = "nuklear-rust"
 source = "crates"
 
 [[crates]]

--- a/content/categories/vr/data.toml
+++ b/content/categories/vr/data.toml
@@ -1,10 +1,5 @@
 [[crates]]
-name = "rust-openvr/rust-openvr"
-source = "github"
-gitter_url = "https://gitter.im/rust-openvr/rust-openvr"
-
-[[crates]]
-name = "rust-webvr"
+name = "libovr"
 source = "crates"
 
 [[crates]]
@@ -16,5 +11,10 @@ name = "rovr"
 source = "crates"
 
 [[crates]]
-name = "libovr"
+name = "rust-openvr/rust-openvr"
+source = "github"
+gitter_url = "https://gitter.im/rust-openvr/rust-openvr"
+
+[[crates]]
+name = "rust-webvr"
 source = "crates"

--- a/content/categories/windowing/data.toml
+++ b/content/categories/windowing/data.toml
@@ -3,11 +3,11 @@ name = "glfw"
 source = "crates"
 
 [[crates]]
-name = "sdl2"
+name = "glutin"
 source = "crates"
 
 [[crates]]
-name = "glutin"
+name = "minifb"
 source = "crates"
 
 [[crates]]
@@ -15,9 +15,9 @@ name = "piston_window"
 source = "crates"
 
 [[crates]]
-name = "winit"
+name = "sdl2"
 source = "crates"
 
 [[crates]]
-name = "minifb"
+name = "winit"
 source = "crates"


### PR DESCRIPTION
I sorted the crates manually with a quick python script, should fix #157 . 
When adding a crate, it's easy to keep alphabetical order.