### PR TITLE
Sort crates at build-time

### DIFF
--- a/templates/categories/page.html
+++ b/templates/categories/page.html
@@ -187,7 +187,7 @@ a taxonomy, which isn't completely accurate since it's more like pages with exte
       </div>
       <div class="ten wide column">
         {# display each box of content #} {% set config = load_data(path = "content/" ~ page.path ~ "data.toml", format="toml") %} {# dynamic
-        data loaded using the crates.io API #} {% if config.crates %} {% for crate in config.crates %} {{ macros::info(crate=crate)
+        data loaded using the crates.io API #} {% if config.crates %} {% for crate in config.crates | sort(attribute="name") %} {{ macros::info(crate=crate)
         }} {% endfor %} {% endif %}
       </div>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -149,7 +149,7 @@
             <div class="ten wide column">
                 <div class="ui four stackable cards">
                     {% set data = load_data(path="content/games/data.toml") %}
-                    {% for game in data.games %} 
+                    {% for game in data.games | sort(attribute="name") %} 
                         <a class="ui card" href="{{ game.link }}">
                             <img class="ui image" src="{{ game.image }}">
                             <div class="content">
@@ -182,7 +182,7 @@
             <div class="ten wide column">
                 <div class="ui four stackable cards">
                     {% set data = load_data(path="content/resources/data.toml") %}
-                    {% for resource in data.resources %} 
+                    {% for resource in data.resources | sort(attribute="name") %} 
                         <a class="ui card" href="{{ resource.link }}">
                             <div class="content">
                                 <div class="header">{{ resource.name | title }}</div>


### PR DESCRIPTION
This is kind of a companion PR to #241 - wanted to see if we could offload some of the effort to Zola.

Sorting the files manually is almost certainly the more efficient option, but I wanted to submit this so I could get it to run on CI and see whether it's *significantly* slower 😄 Having the file sorted manually would also make it easier to navigate when editing, so it still might be worth doing that instead of/as well as this.