### PR TITLE
Fix Discord channel name

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -73,7 +73,7 @@
 <div class="ui vertical stripe">
     <div class="ui text container">
         <p>The main meeting places for people doing gamedev in Rust are on the IRC channel <a href="https://www.irccloud.com/#!/ircs://irc.mozilla.org:6697/%23rust-gamedev">
-                #rust-gamedev@irc.mozilla.org</a> and the #gamedev channel on the <a href=https://bit.ly/rust-community>community-run Discord server</a>.</p>
+                #rust-gamedev@irc.mozilla.org</a> and the #games-and-graphics channel on the <a href=https://bit.ly/rust-community>community-run Discord server</a>.</p>
         <p>Many libraries have their own lively gitter chats, which you can find in their descriptions.</p>
         <p>Also see the <a href="https://www.reddit.com/r/rust_gamedev"><i class="icon reddit alien small"></i>subreddit</a>.</p>
     </div>


### PR DESCRIPTION
First it was `#gamedev`, then it was `#game-dev`, now it's `#games-and-graphics`. It *looks* like they've finally settled on that as the permanent name, so seems like a good idea to update the homepage.