### PR TITLE
Cleanup the templates and styling

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,6 @@
+title = "Are we game yet?"
+description = "A guide to the Rust game development ecosystem."
+
 # The URL the site will be built for
 base_url = "https://arewegameyet.com/"
 

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -92,3 +92,20 @@
         font-size: 1.5em;
     }
 }
+
+/* Colors overridden to avoid inaccessible contrast levels */
+
+a {
+    color: #397AB9;
+}
+
+.ui.card > .extra,
+.ui.cards > .card > .extra,
+.ui.card .meta,
+.ui.cards > .card .meta {
+    color: #767676;
+}
+
+.ui.primary.button, .ui.primary.buttons .button {
+    background-color: #1F7BC1;
+}

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -43,26 +43,24 @@ name
 {% if crate.gitter_url %}       {% set gitter_url = crate.gitter_url %}                 {% endif %}
 {% if crate.description %}      {% set description = crate.description %}               {% endif %}
 <div class="ui one stackable cards">
-    <a name="{{ name }}"></a>
     <div class="ui card">
         <div class="content">
-
-            <a href="#{{ name }}" title="permanent link">
+            <a href="#{{ name }}" id="{{ name }}" aria-label="Permanent link for {{ name }}">
                 <i class="right floated hashtag icon"></i>
             </a>
 
-            <a href="{{ repository_url }}" title="github">
+            <a href="{{ repository_url }}" aria-label="Github link for {{ name }}">
                 <i class="right floated github icon"></i>
             </a>
 
             {% if crate_url %}
-                <a href="{{ crate_url }}" title="crate">
+                <a href="{{ crate_url }}" aria-label="Crates.io link for {{ name }}">
                     <i class="right floated cube icon"></i>
                 </a>
             {% endif %}
 
             {% if homepage_url %}
-            <a href="{{ homepage_url }}" title="home">
+            <a href="{{ homepage_url }}" aria-label="Website link for {{ name }}">
                 <i class="right floated home icon"></i>
             </a>
             {% endif %}
@@ -81,21 +79,21 @@ name
                 <div class="item">
                     <div class="content">
                         <a href="https://crates.io/crates/{{name}}">
-                            <img src="https://img.shields.io/crates/v/{{name}}.svg?maxAge=2592000">
+                            <img src="https://img.shields.io/crates/v/{{name}}.svg?maxAge=2592000" alt="Crates.io link for {{ name }}">
                         </a>
                     </div>
                 </div>
-                <div class="item">
+                <div class="item" aria-hidden="true">
                     <div class="content">
                         <a href="https://crates.io/crates/{{name}}">
-                            <img src="https://img.shields.io/crates/d/{{name}}.svg?maxAge=2592000">
+                            <img src="https://img.shields.io/crates/d/{{name}}.svg?maxAge=2592000" alt="Download count for {{ name }}">
                         </a>
                     </div>
                 </div>
-                <div class="item">
+                <div class="item" aria-hidden="true">
                     <div class="content">
                         <a href="https://crates.io/crates/{{name}}">
-                            <img src="https://img.shields.io/crates/l/{{name}}.svg?maxAge=2592000">
+                            <img src="https://img.shields.io/crates/l/{{name}}.svg?maxAge=2592000" alt="License for {{ name }}">
                         </a>
                     </div>
                 </div>

--- a/templates/categories/page.html
+++ b/templates/categories/page.html
@@ -1,211 +1,228 @@
-{% extends 'master.html' %} {% import "categories/macros.html" as macros %}
+{% extends "master.html" %}
+{% import "macros.html" as macros %}
+{% import "categories/macros.html" as category_macros %}
 
-<!-- a collection of crates, used to be "categories".  However, with Zola, categories implies
-a taxonomy, which isn't completely accurate since it's more like pages with external data loading. -->
+{#
+    a collection of crates, used to be "categories".  However, with Zola, categories implies
+    a taxonomy, which isn't completely accurate since it's more like pages with external data loading.
+#}
 
-{% block content %} 
+{% block seo %}
+    <title>{{ page.title }} | {{ config.title }}</title>
+
+    <meta property="og:title" content="{{ page.title }}">
+    <meta property="og:url" content="{{ page.permalink }}">
+    <meta property="og:description" content="{{ page.description }}">
+    <link rel="canonical" href="{{ page.permalink }}">
+{% endblock seo %}
+
+{% block head %}
 {# unfortunately we need some page-specific css here #}
 <style type="text/css">
-  .hidden.menu {
-    display: none;
-  }
-
-  .masthead.segment {
-    min-height: 70px;
-    padding: 1em 0em;
-  }
-
-  .masthead .logo.item img {
-    margin-right: 1em;
-  }
-
-  .masthead .ui.menu .ui.button {
-    margin-left: 0.5em;
-  }
-
-  .masthead h1.ui.header {
-    margin-top: 3em;
-    margin-bottom: 0em;
-    font-size: 4em;
-    font-weight: normal;
-  }
-
-  .masthead h2 {
-    font-size: 1.7em;
-    font-weight: normal;
-  }
-
-  .ui.vertical.stripe {
-    padding: 8em 0em;
-  }
-
-  .ui.vertical.stripe h3 {
-    font-size: 2em;
-  }
-
-  .ui.vertical.stripe .button+h3,
-  .ui.vertical.stripe p+h3 {
-    margin-top: 3em;
-  }
-
-  .ui.vertical.stripe .floated.image {
-    clear: both;
-  }
-
-  .ui.vertical.stripe p {
-    font-size: 1.33em;
-  }
-
-  .ui.vertical.stripe .horizontal.divider {
-    margin: 3em 0em;
-  }
-
-  .quote.stripe.segment {
-    padding: 0em;
-  }
-
-  .quote.stripe.segment .grid .column {
-    padding-top: 5em;
-    padding-bottom: 5em;
-  }
-
-  .footer.segment {
-    padding: 5em 0em;
-  }
-
-  .secondary.pointing.menu .toc.item {
-    display: none;
-  }
-
-  @media only screen and (max-width: 700px) {
-    .ui.fixed.menu {
-      display: none !important;
+    .hidden.menu {
+        display: none;
     }
-    .secondary.pointing.menu .item,
-    .secondary.pointing.menu .menu {
-      display: none;
-    }
-    .secondary.pointing.menu .toc.item {
-      display: block;
-    }
+
     .masthead.segment {
-      min-height: 350px;
+        min-height: 70px;
+        padding: 1em 0em;
     }
+
+    .masthead .logo.item img {
+        margin-right: 1em;
+    }
+
+    .masthead .ui.menu .ui.button {
+        margin-left: 0.5em;
+    }
+
     .masthead h1.ui.header {
-      font-size: 2em;
-      margin-top: 1.5em;
+        margin-top: 3em;
+        margin-bottom: 0em;
+        font-size: 4em;
+        font-weight: normal;
     }
+
     .masthead h2 {
-      margin-top: 0.5em;
-      font-size: 1.5em;
+        font-size: 1.7em;
+        font-weight: normal;
     }
-  }
-</style>
 
-{# nav #}
+    .ui.vertical.stripe {
+        padding: 8em 0em;
+    }
 
-<div class="ui inverted vertical masthead center aligned segment">
-  <div class="ui container">
-    <div class="ui large secondary inverted pointing menu">
-      <a class="toc item">
-        <i class="sidebar icon"></i>
-      </a>
-      <a class="active item" href="/">Home</a>
-      <a class="item" href="/#chat">Chat</a>
-      <a class="item" href="/#eco">Ecosystem</a>
-      <a class="item" href="/#games">Games</a>
-      <a class="item" href="/#curators">Curators</a>
-      <a class="item" href="/#about">About</a>
-      <div class="right item">
-        <a class="ui inverted button" href="/#res">Resources</a>
-        <a class="ui inverted button" href="https://github.com/doppioslash/arewegameyet">Contribute</a>
-      </div>
-    </div>
-  </div>
+    .ui.vertical.stripe h3 {
+        font-size: 2em;
+    }
 
-  <div class="ui text container">
-    <a href="https://github.com/doppioslash/arewegameyet" class="github-corner" aria-label="View source on Github"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#fff; color:#151513; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
-        <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
-        <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a>
-    <style>
-      .github-corner:hover .octo-arm {
+    .ui.vertical.stripe .button+h3,
+    .ui.vertical.stripe p+h3 {
+        margin-top: 3em;
+    }
+
+    .ui.vertical.stripe .floated.image {
+        clear: both;
+    }
+
+    .ui.vertical.stripe p {
+        font-size: 1.33em;
+    }
+
+    .ui.vertical.stripe .horizontal.divider {
+        margin: 3em 0em;
+    }
+
+    .quote.stripe.segment {
+        padding: 0em;
+    }
+
+    .quote.stripe.segment .grid .column {
+        padding-top: 5em;
+        padding-bottom: 5em;
+    }
+
+    .footer.segment {
+        padding: 5em 0em;
+    }
+
+    .secondary.pointing.menu .toc.item {
+        display: none;
+    }
+
+    @media only screen and (max-width: 700px) {
+        .ui.fixed.menu {
+            display: none !important;
+        }
+
+        .secondary.pointing.menu .item,
+        .secondary.pointing.menu .menu {
+            display: none;
+        }
+
+        .secondary.pointing.menu .toc.item {
+            display: block;
+        }
+
+        .masthead.segment {
+            min-height: 350px;
+        }
+
+        .masthead h1.ui.header {
+            font-size: 2em;
+            margin-top: 1.5em;
+        }
+
+        .masthead h2 {
+            margin-top: 0.5em;
+            font-size: 1.5em;
+        }
+    }
+
+    .github-corner:hover .octo-arm {
         animation: octocat-wave 560ms ease-in-out
-      }
+    }
 
-      @keyframes octocat-wave {
+    @keyframes octocat-wave {
         0%,
         100% {
-          transform: rotate(0)
+            transform: rotate(0)
         }
         20%,
         60% {
-          transform: rotate(-25deg)
+            transform: rotate(-25deg)
         }
         40%,
         80% {
-          transform: rotate(10deg)
+            transform: rotate(10deg)
         }
-      }
+    }
 
-      @media (max-width:500px) {
+    @media (max-width: 500px) {
         .github-corner:hover .octo-arm {
-          animation: none
+            animation: none
         }
         .github-corner .octo-arm {
-          animation: octocat-wave 560ms ease-in-out
+            animation: octocat-wave 560ms ease-in-out
         }
-      }
-    </style>
-    <h2 class="ui inverted header">
-      Are we game yet?
-    </h2>
-  </div>
+    }
+</style>
+{% endblock %}
+
+{% block content %} 
+{# nav #}
+
+<div class="ui inverted vertical masthead center aligned segment">
+    {{ macros::navigation() }} 
+
+    <div class="ui text container">
+        <a href="https://github.com/doppioslash/arewegameyet" class="github-corner" aria-label="View source on Github">
+            <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#fff; color:#151513; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+                <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+                <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+                <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+            </svg>
+        </a>
+        <h2 class="ui inverted header">
+            Are we game yet?
+        </h2>
+    </div>
 </div>
 
 {# Heading #}
 <div class="ui vertical stripe">
-  <h2 class="ui center aligned icon header">
-    <i class="circular game icon"></i>
-    {{page.title}}
-  </h2>
-  <div class="ui text container">
-    <p>{{page.description}}</p>
-  </div>
-</div>
-{# list all content #}
-<a name="crates">
-  <h4 class="ui horizontal divider header">
-    <i class="list icon big"></i>
-    Crates
-  </h4>
-</a>
-
-<div class="ui vertical stripe">
-  <div class="ui grid">
-    <div class="row">
-      <div class="three wide column">
-      </div>
-      <div class="ten wide column">
-        {# display each box of content #} {% set config = load_data(path = "content/" ~ page.path ~ "data.toml", format="toml") %} {# dynamic
-        data loaded using the crates.io API #} {% if config.crates %} {% for crate in config.crates %} {{ macros::info(crate=crate)
-        }} {% endfor %} {% endif %}
-      </div>
+    <h2 class="ui center aligned icon header">
+        <i class="circular game icon"></i>
+        {{page.title}}
+    </h2>
+    <div class="ui text container">
+        <p>{{page.description}}</p>
     </div>
-  </div>
 </div>
 
-<a name="contribute"></a>
+{# list all content #}
+
 <h4 class="ui horizontal divider header">
-  <i class="chat icon big"></i>
-  Contribute
+    <a href="#crates" id="crates">
+        <i class="list icon big"></i>
+        Crates
+    </a>
 </h4>
+
 <div class="ui vertical stripe">
-  <div class="ui text container">
-    <p>Do you know about a missing crate? Did you launch a new crate?</p>
-    <p>Please create <a href="https://github.com/doppioslash/arewegameyet/issues/new?title=Add+crate:+CRATE&amp;body=Please+add+crate+to+category:+2drendering">an
-        issue
-      </a> or a pull request.</p>
-    <p>Looking for a library you can't find here? Try asking on the <a href="/#chat">chat</a>.</p>
-  </div>
+    <div class="ui grid">
+        <div class="row">
+            <div class="ten wide centered column">
+                {# display each box of content #}
+                {% set config = load_data(path = "content/" ~ page.path ~ "data.toml", format="toml") %}
+
+                {# dynamic data loaded using the crates.io API #}
+                {% if config.crates %}
+                    {% for crate in config.crates %}
+                        {{ category_macros::info(crate=crate) }}
+                    {% endfor %}
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+
+<h4 class="ui horizontal divider header">
+    <a href="#contribute" id="contribute">
+        <i class="chat icon big"></i>
+        Contribute
+    </a>
+</h4>
+
+<div class="ui vertical stripe">
+    <div class="ui text container">
+        <p>Do you know about a missing crate? Did you launch a new crate?</p>
+        <p>
+            Please create
+            <a href="https://github.com/doppioslash/arewegameyet/issues/new?title=Add+crate:+CRATE&amp;body=Please+add+crate+to+category:+2drendering">an issue</a>
+            or a pull request.
+        </p>
+        <p>Looking for a library you can't find here? Try asking on the <a href="/#chat">chat</a>.</p>
+    </div>
 </div>
 {% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,94 +1,94 @@
 {% extends 'master.html' %} 
 {% import "macros.html" as macros %}
 {% block content %}
-<!-- Page Contents -->
+
+{# Page Contents #}
+
 <div class="ui inverted vertical masthead center aligned segment">
-    <div class="ui container">
-        <div class="ui large secondary inverted pointing menu">
-            <a class="toc item">
-                <i class="sidebar icon"></i>
-            </a>
-            <a class="active item" href="/">Home</a>
-            <a class="item" href="#chat">Chat</a>
-            <a class="item" href="#news">News</a>
-            <a class="item" href="#eco">Ecosystem</a>
-            <a class="item" href="#games">Games</a>
-            <a class="item" href="#curators">Curators</a>
-            <a class="item" href="#about">About</a>
-            <div class="right item">
-                <a class="ui inverted button" href="#res">Resources</a>
-                <a class="ui inverted button" href="https://github.com/doppioslash/arewegameyet">Contribute</a>
-            </div>
-        </div>
-    </div>
+    {{ macros::navigation() }} 
 
     <div class="ui text container">
-        <a href="https://github.com/doppioslash/arewegameyet" class="github-corner" aria-label="View source on Github"><svg
-                width="80" height="80" viewBox="0 0 250 250" style="fill:#fff; color:#151513; position: absolute; top: 0; border: 0; right: 0;"
-                aria-hidden="true">
+        <a href="https://github.com/doppioslash/arewegameyet" class="github-corner" aria-label="View source on Github">
+            <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#fff; color:#151513; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
                 <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
                 <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
                     fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
                 <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
                     fill="currentColor" class="octo-body"></path>
-            </svg></a>
+            </svg>
+        </a>
         <h1 class="ui inverted header">
             <div>
-                <img class="ui centered image" src="assets/img/rust-logo-128x128-blk-v2-invert.png">
+                <img class="ui centered image" src="assets/img/rust-logo-128x128-blk-v2-invert.png" alt="">
             </div>
             Are we game yet?
         </h1>
         <h2>Almost. We have the blocks, bring your own glue.</h2>
-        <a class="ui huge primary button" href="#get">Get Started <i class="right arrow icon"></i></a>
+        <a class="ui huge primary button" href="#get-started">Get Started <i class="right arrow icon"></i></a>
     </div>
 </div>
 
-<a name="get"></a>
+
 <div class="ui vertical stripe">
     <h2 class="ui center aligned icon header">
         <i class="circular game icon"></i>
-        Get Started
+        <a href="#get-started" id="get-started">
+            Get Started
+        </a>
     </h2>
     <div class="ui text container">
-        <p>Since you ended up here, you probably agree that Rust is potentially an ideal language for Game Development.
+        <p>
+            Since you ended up here, you probably agree that Rust is potentially an ideal language for Game Development.
         </p>
-        <p> Its emphasis on low-level memory safe programming promise a better development process, less debugging time,
-            and better end result.</p>
-        <p>While the ecosystem is still very young, you can find enough libraries and game engines to sink your teeth into
-            doing some slightly experimental gamedev.</p>
-        <p>If you haven't learned Rust yet, maybe take a look at <a href="#res"><i class="icon list small"></i>Resources</a>
+        <p>
+            Its emphasis on low-level memory safe programming promise a better development process, less debugging time,
+            and better end result.
+        </p>
+        <p>
+            While the ecosystem is still very young, you can find enough libraries and game engines to sink your teeth into
+            doing some slightly experimental gamedev.
+        </p>
+        <p>
+            If you haven't learned Rust yet, maybe take a look at <a href="#res"><i class="icon list small"></i>Resources</a>
             first. If you are already proficient with Rust you might want to start with <a href="#eco"><i class="icon grid layout small"></i>Ecosystem</a>,
             <a href="#news"><i class="icon newspaper small"></i>News</a>
-            or <a href="#chat"><i class="icon chat small"></i>Chat</a>.</p>
+            or <a href="#chat"><i class="icon chat small"></i>Chat</a>.
+        </p>
     </div>
 </div>
 
-<a href="#" name="chat">
-    <h4 class="ui horizontal divider header">
+
+<h4 class="ui horizontal divider header">
+    <a href="#chat" id="chat">
         <i class="chat icon big"></i>
         Chat
-    </h4>
-</a>
+    </a>
+</h4>
 
 <div class="ui vertical stripe">
     <div class="ui text container">
-        <p>The main meeting places for people doing gamedev in Rust are on the IRC channel <a href="https://www.irccloud.com/#!/ircs://irc.mozilla.org:6697/%23rust-gamedev">
-                #rust-gamedev@irc.mozilla.org</a> and the #games-and-graphics channel on the <a href=https://bit.ly/rust-community>community-run Discord server</a>.</p>
+        <p>
+            The main meeting places for people doing gamedev in Rust are on the IRC channel
+            <a href="https://www.irccloud.com/#!/ircs://irc.mozilla.org:6697/%23rust-gamedev">#rust-gamedev@irc.mozilla.org</a>
+            and the #games-and-graphics channel on the <a href=https://bit.ly/rust-community>community-run Discord server</a>.
+        </p>
         <p>Many libraries have their own lively gitter chats, which you can find in their descriptions.</p>
         <p>Also see the <a href="https://www.reddit.com/r/rust_gamedev"><i class="icon reddit alien small"></i>subreddit</a>.</p>
     </div>
 </div>
 
-<a href="#" name="news">
-    <h4 class="ui horizontal divider header">
+
+<h4 class="ui horizontal divider header">
+    <a href="#news" id="news">
         <i class="newspaper icon big"></i>
         News
-    </h4>
-</a>
+    </a>
+</h4>
 
 <div class="ui vertical stripe">
     <div class="ui text container">
-        <p>The latest Rust gamedev news are available at:
+        <p>
+            The latest Rust gamedev news are available at:
             the <a href="https://www.reddit.com/r/rust_gamedev"><i class="icon reddit alien small"></i>subreddit</a>,
             the monthly  <a href="https://rust-gamedev.github.io/"><i class="icon newspaper small"></i>newsletter</a>,
             and the <a href="https://twitter.com/rust_gamedev"><i class="icon twitter small"></i>@rust_gamedev</a> Twitter feed.
@@ -96,62 +96,57 @@
     </div>
 </div>
 
-<a href="#" name="eco">
-    <h4 class="ui horizontal divider header">
+<h4 class="ui horizontal divider header">
+    <a href="#eco" id="eco">
         <i class="icon grid layout big"></i>
         Ecosystem
-    </h4>
-</a>
+    </a>
+</h4>
 
 <div class="ui vertical stripe">
     <div class="ui grid">
         <div class="row">
-            <div class="three wide column"></div>
-            <div class="ten wide column">
+            <div class="ten wide centered column">
                 <div class="ui four stackable cards">
-                    {% set categories = get_section(path="categories/_index.md") %} {% for category in categories.pages %} {% set data = load_data(path="content/" ~ category.path
-                    ~ "data.toml") %}
-                    <a class="ui card" href="{{category.permalink}}">
-                        <div class="content">
-                            <div class="header">{{ category.title }}</div>
-                            <div class="description">{{ category.description }}</div>
-                        </div>
-                        <div class="extra content">
-                            <i class="cube icon"></i>
-                            {% if data.crates %} {{ data.crates | length }} Crates {% endif %}
-                        </div>
-                        <div class="ui bottom teal attached button">
-                            Browse
-                        </div>
-                    </a>
+                    {% set categories = get_section(path="categories/_index.md") %}
+                    {% for category in categories.pages %}
+                        {% set data = load_data(path="content/" ~ category.path ~ "data.toml") %}
+                        <a class="ui card" href="{{category.permalink}}">
+                            <div class="content">
+                                <div class="header">{{ category.title }}</div>
+                                <div class="description">{{ category.description }}</div>
+                            </div>
+                            <div class="extra content">
+                                <i class="cube icon"></i>
+                                {% if data.crates %} {{ data.crates | length }} Crates {% endif %}
+                            </div>
+                            <div class="ui bottom primary attached button">
+                                Browse
+                            </div>
+                        </a>
                     {% endfor %}
                 </div>
-            </div>
-            <div class="three wide column">
             </div>
         </div>
     </div>
 </div>
 
-<a name="games"></a>
 <h4 class="ui horizontal divider header">
-    <a href="#">
+    <a href="#games" id="games">
         <i class="game icon big"></i>
         Games
+    </a>
 </h4>
-</a>
 
 <div class="ui vertical stripe">
     <div class="ui grid">
         <div class="row">
-            <div class="three wide column">
-            </div>
-            <div class="ten wide column">
+            <div class="ten wide centered column">
                 <div class="ui four stackable cards">
                     {% set data = load_data(path="content/games/data.toml") %}
                     {% for game in data.games %} 
                         <a class="ui card" href="{{ game.link }}">
-                            <img class="ui image" src="{{ game.image }}">
+                            <img class="ui image" src="{{ game.image }}" alt="Screenshot of {{ game.name }}">
                             <div class="content">
                                 <div class="header">{{ game.name }}</div>
                                 <div class="description">
@@ -162,24 +157,21 @@
                     {% endfor %}
                 </div>
             </div>
-            <div class="three wide column">
-            </div>
         </div>
     </div>
 </div>
 
-<a name="res"></a>
 <h4 class="ui horizontal divider header">
-    <a href="#">
+    <a href="#res" id="res">
         <i class="list icon big"></i>
-        Resources</a>
+        Resources
+    </a>
 </h4>
 
 <div class="ui vertical stripe">
     <div class="ui grid">
         <div class="row">
-            <div class="three wide column"></div>
-            <div class="ten wide column">
+            <div class="ten wide centered column">
                 <div class="ui four stackable cards">
                     {% set data = load_data(path="content/resources/data.toml") %}
                     {% for resource in data.resources %} 
@@ -191,30 +183,28 @@
                                     {{ resource.description }}
                                 </div>
                             </div>
-                            <div class="ui bottom teal attached button">
+                            <div class="ui bottom primary attached button">
                                 Open
                             </div>
                         </a>
                     {% endfor %}
                 </div>
             </div>
-            <div class="three wide column"></div>
         </div>
     </div>
 </div>
 
-<a name="curators"></a>
 <h4 class="ui horizontal divider header">
-    <a href="#">
+    <a href="#curators" id="curators">
         <i class="users icon big"></i>
-        Curators</a>
+        Curators
+    </a>
 </h4>
 
 <div class="ui vertical stripe">
     <div class="ui equal width stackable grid">
         <div class="center aligned row">
-            <div class="three wide column"></div>
-            <div class="ten wide column">
+            <div class="ten wide centered column">
                 <div class="ui three cards">
                     {% set data = load_data(path="content/contributors/data.toml") %}
                     {{ macros::contributors(contributors=data.contributors) }} 
@@ -222,34 +212,33 @@
             </div>
         </div>
         <div class="center aligned row">
-            <div class="six wide column"></div>
-            <div class="four wide column">
+            <div class="four wide centered column">
                 <h3>Contribute</h3>
                 <p>And put your name here.</p>
-                <a href="https://github.com/doppioslash/arewegameyet" class="ui icon button positive">
+                <a href="https://github.com/doppioslash/arewegameyet" class="ui icon button positive" aria-label="Go to Github">
                     <i class="add icon large"></i>
                 </a>
             </div>
-            <div class="six wide column"></div>
         </div>
-        <div class="center aligned row"></div>
     </div>
+</div>
 
+<h4 class="ui horizontal divider header">
+    <a href="#about" id="about">
+        <i class="user icon big"></i>
+        About
+    </a>
+</h4>
 
-
-    <a name="about"></a>
-    <h4 class="ui horizontal divider header">
-        <a href="#">
-            <i class="user icon big"></i>
-            About</a>
-    </h4>
-
-    <div class="ui vertical stripe">
-        <div class="ui text container">
-            <p><b>Arewegameyet?</b> is made by <a href="https://twitter.com/doppioslash"><i class="twitter icon"></i>@doppioslash</a>
-                and powered by <a href="https://github.com/getzola/zola">Zola</a>, a Rust static site generator.</p>
-            <p>Inspired by <a href="https://www.arewewebyet.org/">arewewebyet</a>, and <a href="https://www.arewelearningyet.com/">arewelearningyet</a>.</p>
-        </div>
+<div class="ui vertical stripe">
+    <div class="ui text container">
+        <p>
+            <strong>Arewegameyet?</strong> is made by <a href="https://twitter.com/doppioslash"><i class="twitter icon"></i>@doppioslash</a>
+            and powered by <a href="https://github.com/getzola/zola">Zola</a>, a Rust static site generator.
+        </p>
+        <p>
+            Inspired by <a href="https://www.arewewebyet.org/">arewewebyet</a>, and <a href="https://www.arewelearningyet.com/">arewelearningyet</a>.
+        </p>
     </div>
 </div>
 {% endblock content %}

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,3 +1,25 @@
+{% macro navigation() %}
+    <div class="ui container">
+        <div class="ui large secondary inverted pointing menu">
+            <a class="toc item">
+                <i class="sidebar icon"></i>
+            </a>
+            <a class="active item" href="/">Home</a>
+            <a class="item" href="/#chat">Chat</a>
+            <a class="item" href="/#news">News</a>
+            <a class="item" href="/#eco">Ecosystem</a>
+            <a class="item" href="/#games">Games</a>
+            <a class="item" href="/#curators">Curators</a>
+            <a class="item" href="/#about">About</a>
+            <div class="right item">
+                <a class="ui inverted button" href="/#res">Resources</a>
+                <a class="ui inverted button" href="https://github.com/doppioslash/arewegameyet">Contribute</a>
+            </div>
+        </div>
+    </div>
+{% endmacro %}
+
+
 {% macro contributors(contributors) %}
     {% for c in contributors %}
         <div class="ui card">
@@ -6,16 +28,16 @@
                 {% for name, link in c.links %}
                     {# special links for social websites with icons #}
                     {% if name == "twitter" or name == "github" %}
-                        <a href="https://{{name}}.com/{{link}}" title="{{name}} link">
+                        <a href="https://{{name}}.com/{{link}}" aria-label="{{name}} link for {{ c.name }}">
                             <i class="{{name}} icon large"></i>
                         </a>
                     {% elif name == "home" %}
-                        <a href="{{link}}" title="{{name}} link">
+                        <a href="{{link}}" aria-label="Website link for {{ c.name }}">
                             <i class="{{name}} icon large"></i>
                         </a>
                     {# any other website #}
                     {% else %}
-                        <a href="{{link}}" title="{{name}} link">
+                        <a href="{{link}}" title="{{name}} link for {{ c.name }}">
                             <i class="world icon large"></i>
                         </a>
                     {% endif %}

--- a/templates/master.html
+++ b/templates/master.html
@@ -1,55 +1,36 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <!-- Standard Meta -->
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <!-- Site Properties -->
-    <title>Are we game yet? - Rust</title>
+    {% block seo %}
+        <title>{{ config.title }}</title>
 
-    <link rel='shortcut icon' href='favicon.ico' type='image/x-icon' />
+        <meta property="og:title" content="{{ config.title }}">
+        <meta name="description" content="{{ config.description }}">
+        <meta property="og:description" content="{{ config.description }}">
+        <meta property="og:url" content="{{ get_url(path='/')}}">
+        <link rel="canonical" href="{{ get_url(path='/')}}">
+    {% endblock seo %}
+
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="{{ get_url(path='assets/img/rust-logo-128x128-blk-v2.png')}}">
+    <meta property="og:image:width" content="200">
+    <meta property="og:image:height" content="200">
+    <meta property="og:site_name" content="{{ config.title }}">
+
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css">
-    <link rel="stylesheet" href="main.css">
-
-    <script src="https://code.jquery.com/jquery-3.1.0.min.js" integrity="sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="
-        crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.js"></script>
-    <script src="//load.sumome.com/" data-sumo-site-id="665c1f3e0219632a366981f4bd60c50461ccd7f2c0f661658eccb4097d20c2bc" async="async"></script>
-    <script>
-        $(document)
-            .ready(function () {
-                // fix menu when passed
-                $('.masthead')
-                    .visibility({
-                        once: false,
-                        onBottomPassed: function () {
-                            $('.fixed.menu').transition('fade in');
-                        },
-                        onBottomPassedReverse: function () {
-                            $('.fixed.menu').transition('fade out');
-                        }
-                    })
-                    ;
-
-                // create sidebar and attach to menu open
-                $('.ui.sidebar')
-                    .sidebar('attach events', '.toc.item')
-                    ;
-
-            })
-            ;
-    </script>
-    <script type="text/javascript">
-        window.heap = window.heap || [], heap.load = function (e, t) { window.heap.appid = e, window.heap.config = t = t || {}; var r = t.forceSSL || "https:" === document.location.protocol, a = document.createElement("script"); a.type = "text/javascript", a.async = !0, a.src = (r ? "https:" : "http:") + "//cdn.heapanalytics.com/js/heap-" + e + ".js"; var n = document.getElementsByTagName("script")[0]; n.parentNode.insertBefore(a, n); for (var o = function (e) { return function () { heap.push([e].concat(Array.prototype.slice.call(arguments, 0))) } }, p = ["addEventProperties", "addUserProperties", "clearEventProperties", "identify", "removeEventProperty", "setEventProperties", "track", "unsetEventProperty"], c = 0; c < p.length; c++)heap[p[c]] = o(p[c]) };
-        heap.load("3611386023");
-    </script>
+    <link rel="stylesheet" href="/main.css">
+    
+    {% block head %} {% endblock %}
 </head>
 
 <body>
-
     <div class="ui large top fixed hidden menu">
         <div class="ui container">
             <a class="active item" href="/">Home</a>
@@ -86,7 +67,6 @@
     <div class="ui inverted vertical footer segment">
         <div class="ui container">
             <div class="ui stackable inverted divided equal height stackable grid">
-
                 <div class="three wide column">
                     <h4 class="ui inverted header">About</h4>
                     <div class="ui inverted link list">
@@ -106,6 +86,35 @@
             </div>
         </div>
     </div>
+    
+    <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.js"></script>
+    <script src="//load.sumome.com/" data-sumo-site-id="665c1f3e0219632a366981f4bd60c50461ccd7f2c0f661658eccb4097d20c2bc"></script>
+
+    <script>
+        $(document).ready(function () {
+            // fix menu when passed
+            $('.masthead').visibility({
+                once: false,
+                onBottomPassed: function () {
+                    $('.fixed.menu').transition('fade in');
+                },
+                onBottomPassedReverse: function () {
+                    $('.fixed.menu').transition('fade out');
+                }
+            });
+
+            // create sidebar and attach to menu open
+            $('.ui.sidebar').sidebar('attach events', '.toc.item');
+        });
+    </script>
+    
+    <script type="text/javascript">
+        window.heap = window.heap || [], heap.load = function (e, t) { window.heap.appid = e, window.heap.config = t = t || {}; var r = t.forceSSL || "https:" === document.location.protocol, a = document.createElement("script"); a.type = "text/javascript", a.async = !0, a.src = (r ? "https:" : "http:") + "//cdn.heapanalytics.com/js/heap-" + e + ".js"; var n = document.getElementsByTagName("script")[0]; n.parentNode.insertBefore(a, n); for (var o = function (e) { return function () { heap.push([e].concat(Array.prototype.slice.call(arguments, 0))) } }, p = ["addEventProperties", "addUserProperties", "clearEventProperties", "identify", "removeEventProperty", "setEventProperties", "track", "unsetEventProperty"], c = 0; c < p.length; c++)heap[p[c]] = o(p[c]) };
+        heap.load("3611386023");
+    </script>
+    
+    {% block footer %} {% endblock %}
 </body>
 
 </html>


### PR DESCRIPTION
Been meaning to do this for a while!

Summary of the changes:

* Cleaned up some of the markup
    * I generally went through and tried to remove redundant tags and reformat stuff to be more maintainable where possible - bikeshedding on how exactly stuff should be laid out is welcome 🚲🏠 
    * Where there were anchor tags for sections of the page, I've switched them to use the `id` attribute instead of the `name` attribute (the latter isn't valid in the HTML5 spec, I don't think?), and made sure that clicking the anchor always populates the hash into the address bar. This should help if people want to share links.
    * I pulled out the nav bar into a macro so it wouldn't need to be duplicated.
    * I added some extra blocks to the template to make it easier to inject stuff in the header/end of the document from a child template.
* Sped up page loads
    * The scripts are now loaded asyncronously, so that rendering isn't blocked while they load.
    * TODO: The game images are huge despite being displayed at a small size, and this is contributing massively to the page load times. Will try and think of how we should handle this.
* Improved accessibility (100% score on the Lighthouse audit 🎉)
    * I added a `lang="en"` attribute to the `html` element, since all the content is in English and we don't currently have translations.
    * I removed `maximum-scale` from the `viewport ` meta tag, as being able to zoom in is useful for people with bad vision.
    * Some of the color schemes chosen by Semantic UI out of the box [did not have enough contrast](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html), so I used accessible-colors.com to try and tweak them without making major changes to the look of the site. The only big difference is I had to replace the teal buttons with blue buttons, but that looks more consistent with the header IMO.
    * I've added alt text and ARIA labels where needed - there were `title` attributes on a lot of things already, but apparently screen reader support for that is flaky.
* Improved SEO
    * I've added full meta tags and OpenGraph annotations, so the pages should show up nicer on Google and social media now.

I was going to upload a preview to Netlify, but I seem to no longer be able to build the site locally due to hitting GitHub's rate limits 😅 I will add it once that's worn off.