### PR TITLE
Add SPIRQ as shader tool

### DIFF
--- a/content/categories/shader/data.toml
+++ b/content/categories/shader/data.toml
@@ -5,3 +5,7 @@ source = "crates"
 [[crates]]
 name = "spirv-reflect"
 source = "crates"
+
+[[crates]]
+name = "spirq"
+source = "crates"


### PR DESCRIPTION
[SPIRQ](https://crates.io/crates/spirq) is an alternative to `spirv-reflect`.