### PR TITLE
Mobile styling cleanup

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -1,11 +1,3 @@
-.top.fixed.menu {
-    display: none;
-}
-
-.masthead .ui.menu .ui.button {
-    margin-left: 0.5em;
-}
-
 .masthead .text.container {
     margin: 3em 0;
 }
@@ -18,30 +10,35 @@
 .masthead h2 {
     font-size: 1.7em;
     font-weight: normal;
+    margin: 1.2em 0;
 }
 
-.vertical.stripe {
+.masthead .ui.menu .toc.item {
+    display: none;
+}
+
+.horizontal.divider.header {
+    margin: 0;
+}
+
+.horizontal.divider.header a {
+    padding: 2em 1em; 
+}
+
+.vertical.stripe, .vertical.stripe .text.container {
     margin: 8em 0em;
-}
-
-.vertical.stripe h3 {
-    font-size: 2em;
 }
 
 .vertical.stripe .text.container p {
     font-size: 1.33em;
 }
 
-.vertical.stripe .text.container {
-    margin: 8em 0em;
+.vertical.stripe h3 {
+    font-size: 2em;
 }
 
 .footer.segment {
     padding: 5em 0em;
-}
-
-.secondary.pointing.menu .toc.item {
-    display: none;
 }
 
 .ui.card .image {
@@ -55,14 +52,23 @@
     border-radius: 0;
 }
 
-@media only screen and (max-width: 700px) {
-    .secondary.pointing.menu .item,
-    .secondary.pointing.menu .menu {
+.ui.horizontal.list > .item {
+    margin-left: 0;
+    margin-right: 0.5em;
+}
+
+@media only screen and (max-width: 991px) {
+    .masthead .ui.menu a.item {
         display: none;
     }
 
-    .secondary.pointing.menu .toc.item {
-        display: block;
+    .masthead .ui.menu .toc.item {
+        display: flex;
+        border-radius: 0;
+    }
+
+    .masthead .ui.menu .toc.item .icon {
+        margin: 0;
     }
 
     .masthead h1.header {
@@ -71,6 +77,14 @@
 
     .masthead h2 {
         font-size: 1.5em;
+    }
+
+    .vertical.stripe, .vertical.stripe .text.container {
+        margin: 4em 0em;
+    }
+
+    .vertical.stripe .text.container p {
+        font-size: 1.1em;
     }
 }
 

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -99,7 +99,7 @@
         <div class="extra content">
             {# only projects hosted on crates get badges for now #}
             
-            <div class="ui left floated horizontal list">
+            <div class="ui horizontal list">
                 {% if item.source and item.source == 'crates' %}
                     <div class="item">
                         <div class="content">

--- a/templates/master.html
+++ b/templates/master.html
@@ -31,25 +31,6 @@
 </head>
 
 <body>
-    <div class="ui large top fixed hidden menu">
-        <div class="ui container">
-            <a class="item" href="/">Home</a>
-            <a class="item" href="/#chat">Chat</a>
-            <a class="item" href="/#ecosystem">Ecosystem</a>
-            <a class="item" href="/#games">Games</a>
-            <a class="item" href="/#curators">Curators</a>
-            <a class="item" href="/#about">About</a>
-            <div class="right menu">
-                <div class="item">
-                    <a class="ui button" href="/#res">Resources</a>
-                </div>
-                <div class="item">
-                    <a class="ui primary button" href="https://github.com/rust-gamedev/arewegameyet">Contribute</a>
-                </div>
-            </div>
-        </div>
-    </div>
-
     <!-- Sidebar Menu -->
     <div class="ui vertical inverted sidebar menu">
         <a class="item" href="/">Home</a>
@@ -57,13 +38,14 @@
         <a class="item" href="/#ecosystem">Ecosystem</a>
         <a class="item" href="/#games">Games</a>
         <a class="item" href="/#curators">Curators</a>
+        <a class="item" href="/#resources">Resources</a>
         <a class="item" href="/#about">About</a>
     </div>
 
     <div class="pusher">
         <div class="ui inverted vertical masthead center aligned segment">
             <div class="ui container">
-                <div class="ui large secondary inverted pointing menu">
+                <div class="ui large borderless inverted menu">
                     <a class="toc item">
                         <i class="sidebar icon"></i>
                     </a>
@@ -72,18 +54,18 @@
                     <a class="item" href="/#news">News</a>
                     <a class="item" href="/#ecosystem">Ecosystem</a>
                     <a class="item" href="/#games">Games</a>
+                    <a class="item" href="/#resources">Resources</a>
                     <a class="item" href="/#curators">Curators</a>
                     <a class="item" href="/#about">About</a>
-                    <div class="right item">
-                        <a class="ui inverted button" href="/#res">Resources</a>
-                        <a class="ui inverted button" href="https://github.com/rust-gamedev/arewegameyet">Contribute</a>
+                    <div class="right menu">
+                        <div class="item">
+                            <a class="ui inverted button" href="https://github.com/rust-gamedev/arewegameyet">Contribute</a>
+                        </div>
                     </div>
                 </div>
             </div>
 
             <div class="ui text container">
-                
-
                 {% block masthead %}
                     <h2 class="ui inverted header">
                         Are we game yet?
@@ -93,25 +75,25 @@
         </div>
 
         {% block content %} {% endblock %}
-    </div>
 
-    <div class="ui inverted vertical footer segment">
-        <div class="ui container">
-            <div class="ui stackable inverted divided equal height stackable grid">
-                <div class="three wide column">
-                    <h4 class="ui inverted header">About</h4>
-                    <div class="ui inverted link list">
-                        <a href="/#about" class="item">Contact Us</a>
+        <div class="ui inverted vertical footer segment">
+            <div class="ui container">
+                <div class="ui stackable inverted divided equal height stackable grid">
+                    <div class="three wide column">
+                        <h4 class="ui inverted header">About</h4>
+                        <div class="ui inverted link list">
+                            <a href="/#about" class="item">Contact Us</a>
+                        </div>
                     </div>
-                </div>
-                <div class="ten wide column">
-                    <h4 class="ui inverted header">Arewegameyet?</h4>
-                    <p>CC-BY 2016</p>
-                </div>
-                <div class="three wide column">
-                    <h4 class="ui inverted header">Get involved</h4>
-                    <div class="ui inverted link list">
-                        <a href="https://github.com/rust-gamedev/arewegameyet" class="item">Contribute</a>
+                    <div class="ten wide column">
+                        <h4 class="ui inverted header">Arewegameyet?</h4>
+                        <p>CC-BY 2016</p>
+                    </div>
+                    <div class="three wide column">
+                        <h4 class="ui inverted header">Get involved</h4>
+                        <div class="ui inverted link list">
+                            <a href="https://github.com/rust-gamedev/arewegameyet" class="item">Contribute</a>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -144,7 +126,14 @@
             });
 
             // create sidebar and attach to menu open
-            $('.ui.sidebar').sidebar('attach events', '.toc.item');
+            $('.ui.sidebar')
+                .sidebar('setting', 'transition', 'overlay')
+                .sidebar('setting', 'mobileTransition', 'overlay')
+                .sidebar('attach events', '.toc.item');
+
+            $('.ui.sidebar .item').on('click', function (event) {
+                $('.ui.sidebar').sidebar('hide');
+            })
         });
     </script>
     


### PR DESCRIPTION
A few more styling/functionality fixes for you to look over :)

* Removed the sticky header (it seemed to be [causing more issues than it solved](https://github.com/rust-gamedev/arewegameyet/issues/52) - not sure if we should replace it with something?)
* Fixed broken links to the 'resources' section
* Turned 'resources' from a button into a normal header link for consistency
* Made it so the sidebar links actually close the sidebar
* Made the padding and text size a little bit smaller on mobile for readability
* Added some more padding around headers so jumping to the anchor doesn't put them right at the top of the screen
* Changed the mobile breakpoint to match the one defined by Semantic UI (so you don't get a 'half-desktop, half-mobile' view at certain sized)
* Fixed an issue where the badges on a crate would look weird and misaligned on small screens
* Fixed an issue where opening the sidebar wouldn't shove the footer to the side

Fixes #268, and indirectly fixes #52.