### PR TITLE
Update miniquad metadata

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -502,7 +502,8 @@ categories = ["audio"]
 [[items]]
 name = "miniquad"
 source = "crates"
-categories = ["2drendering"]
+categories = ["2drendering", "3drendering"]
+homepage_url = "https://github.com/not-fl3/miniquad"
 
 [[items]]
 name = "mint"


### PR DESCRIPTION
Miniquad is general-purpose graphics api wrapper, not 2d specific, so 3drendering is a more accurate category.