### PR TITLE
Added shaderc

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -855,6 +855,11 @@ source = "crates"
 categories = ["audio"]
 
 [[items]]
+name = "shaderc"
+source = "crates
+categories = ["shader"]
+
+[[items]]
 name = "sharecart1000"
 source = "crates"
 categories = ["tools"]

--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -856,7 +856,7 @@ categories = ["audio"]
 
 [[items]]
 name = "shaderc"
-source = "crates
+source = "crates"
 categories = ["shader"]
 
 [[items]]


### PR DESCRIPTION
shaderc is a library owned by Google. It is useful for compiling GLSL and HLSL shaders to SPIR-V.