### PR TITLE
Add text rendering category (and ab_glyph)

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -1,4 +1,9 @@
 [[items]]
+name = "ab_glyph"
+source = "crates"
+categories = ["ui", "2drendering", "textrendering"]
+
+[[items]]
 name = "alto"
 source = "crates"
 categories = ["audio"]
@@ -293,7 +298,7 @@ categories = ["audio"]
 [[items]]
 name = "fontdue"
 source = "crates"
-categories = ["ui", "2drendering", "tools"]
+categories = ["ui", "2drendering", "textrendering"]
 
 [[items]]
 name = "froggy"
@@ -905,7 +910,7 @@ categories = ["scripting"]
 [[items]]
 name = "rusttype"
 source = "crates"
-categories = ["2drendering", "tools"]
+categories = ["ui", "2drendering", "textrendering"]
 
 [[items]]
 name = "rusty_engine"

--- a/content/ecosystem/textrendering.md
+++ b/content/ecosystem/textrendering.md
@@ -1,0 +1,5 @@
++++
+title = "Text Rendering"
+description = "Libraries and tools for loading and rendering fonts"
+aliases = ["/categories/textrendering"]
++++


### PR DESCRIPTION
I feel like the 'tools' category is turning into a bit of a dumping group for things we don't know how to categorize, and there's a decent number of text rendering libraries in Rust - would it make sense for us to add a category for them?

I also added `ab_glyph` to the list for completeness, and made sure they all have the same three categories.