### PR TITLE
Rebuild the page once a week & Personal Access Token is no longer needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
       BASE_URL: https://github.com/getzola/zola/releases/download
       VERS: v0.10.1
       ARCH: x86_64-unknown-linux-gnu
-      # https://github.com/marketplace/actions/github-pages#warning-limitation
-      GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+      # https://github.com/crazy-max/ghaction-github-pages/issues/1#issuecomment-623202206
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v1
     - name: Install Zola

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: Zola
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * MON' # Weekly, Mondays at 00:00
 
 jobs:
   zola:


### PR DESCRIPTION
This PR makes sure that the page is rebuilt at least once a week for updated crate or repo descriptions etc.

Also the personal access token is no longer needed and makes it easier to test it on forks.
see https://github.com/crazy-max/ghaction-github-pages/issues/1#issuecomment-623202206
> Personal Access Token is not required anymore to trigger a page build on a public repository. Nothing official from GitHub but everything seems to work for me on several repositories with the built-in GITHUB_TOKEN (public and private).