### PR TITLE
Add recent download count to crates

### DIFF
--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -126,6 +126,13 @@
                     <div class="item" aria-hidden="true">
                         <div class="content">
                             <a href="https://crates.io/crates/{{name}}">
+                                <img src="https://img.shields.io/crates/dr/{{name}}.svg?maxAge=2592000" alt="Recent download count for {{ name }}">
+                            </a>
+                        </div>
+                    </div>
+                    <div class="item" aria-hidden="true">
+                        <div class="content">
+                            <a href="https://crates.io/crates/{{name}}">
                                 <img src="https://img.shields.io/crates/l/{{name}}.svg?maxAge=2592000" alt="License for {{ name }}">
                             </a>
                         </div>


### PR DESCRIPTION
Recent downloads is a bit of a better metric of current popularity than all-time downloads, so it might be nice for us to expose this metric in the UI?

![image](https://user-images.githubusercontent.com/784533/102690953-d8395000-4200-11eb-8fa1-b4100e41773a.png)

I could also adjust the label on the existing downloads icon, if people think that'd make it clearer what the distinction is between the two metrics.