### PR TITLE
Add bevy to the ecs category

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -67,7 +67,12 @@ categories = ["2drendering"]
 [[items]]
 name = "bevy"
 source = "crates"
-categories = ["engines", "ecs"]
+categories = ["engines"]
+
+[[items]]
+name = "bevy_ecs"
+source = "crates"
+categories = ["ecs"]
 
 [[items]]
 name = "big-brain"

--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -67,7 +67,7 @@ categories = ["2drendering"]
 [[items]]
 name = "bevy"
 source = "crates"
-categories = ["engines"]
+categories = ["engines", "ecs"]
 
 [[items]]
 name = "big-brain"


### PR DESCRIPTION
bevy_ecs can be used separately from the rest of the engine, so it makes sense to add it here aswell.