### PR TITLE
Add Quilkin to networking category

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -885,6 +885,11 @@ source = "crates"
 categories = ["engines"]
 
 [[items]]
+name = "quilkin"
+source = "crates"
+categories = ["networking"]
+
+[[items]]
 name = "quinn"
 source = "crates"
 categories = ["networking"]
@@ -1249,8 +1254,3 @@ categories = ["physics"]
 name = "wrapping_coords2d"
 source = "crates"
 categories = ["tools"]
-
-[[items]]
-name = "quilkin"
-source = "crates"
-categories = ["networking"]

--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -1249,3 +1249,8 @@ categories = ["physics"]
 name = "wrapping_coords2d"
 source = "crates"
 categories = ["tools"]
+
+[[items]]
+name = "quilkin"
+source = "crates"
+categories = ["networking"]


### PR DESCRIPTION
Quilkin is a non-transparent UDP proxy specifically designed for use with large scale multiplayer dedicated game servers deployments, to ensure security, access control, telemetry data, metrics and more.

It is designed to be used behind game clients as well as in front of dedicated game servers.