### PR TITLE
Revert "naia-rs/naia moved to the amethyst org (#393)"

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -19,11 +19,6 @@ source = "crates"
 categories = ["engines"]
 
 [[items]]
-name = "amethyst/naia"
-source = "github"
-categories = ["networking"]
-
-[[items]]
 name = "amethyst_network"
 source = "crates"
 categories = ["networking"]
@@ -694,6 +689,11 @@ name = "naga"
 source = "crates"
 categories = ["shader"]
 homepage_url = "https://github.com/gfx-rs/naga"
+
+[[items]]
+name = "naia-rs/naia"
+source = "github"
+categories = ["networking"]
 
 [[items]]
 name = "nalgebra"


### PR DESCRIPTION
This reverts commit 4305c164133e0cf25ccc7047b1a410b78909b6fb.

Sorry for the noise.
It's back to the naia-rs org. See redirect https://github.com/amethyst/naia