### PR TITLE
Reduce load on Crates.io

### DIFF
--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -6,7 +6,7 @@
 
 {% if item.source %}
     {% if item.source == 'crates' %}
-        {% set data = load_data(url = "https://crates.io/api/v1/crates/" ~ item.name, format="json") %}
+        {% set data = load_data(url = "https://crates.io/api/v1/crates/" ~ item.name ~ "?include=", format="json", headers=["User-Agent=arewegameyet"]) %}
         {# human readable name #}
         {% set name = data.crate.name %}
         {# Github/Gitlab/Etc. repository #}

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -6,7 +6,7 @@
 
 {% if item.source %}
     {% if item.source == 'crates' %}
-        {% set data = load_data(url = "https://crates.io/api/v1/crates/" ~ item.name ~ "?include=", format="json", headers=["User-Agent=arewegameyet"]) %}
+        {% set data = load_data(url = "https://crates.io/api/v1/crates/" ~ item.name ~ "?include=", format="json", headers=["User-Agent=arewegameyet (gamedev-wg@rust-lang.org)"]) %}
         {# human readable name #}
         {% set name = data.crate.name %}
         {# Github/Gitlab/Etc. repository #}


### PR DESCRIPTION
This is a partial fix for #378 - adding `?include=` to the API call excludes a load of information which we don't use from the response, and apparently reduces the number of queries from six to one. Should benefit our build times, and reduces the chance we get rate limited.

I also added a `User-Agent` header to the requests, in line with Crates.io's [crawling policy](https://crates.io/policies#crawlers) (so they know who to shout at if we overload the API 😄)