### PR TITLE
Updated hompage of ellie-lang. 

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -285,7 +285,7 @@ description = "A type-safe scripting language"
 categories = ["scripting"]
 image = "/assets/img/ellie_language.png"
 repository_url = "https://github.com/behemehal/Ellie-Language"
-homepage_url = "https://ellie.behemehal.net"
+homepage_url = "https://www.ellie-lang.org/"
 gitter_url = "https://gitter.im/ellie-lang/community"
 
 [[items]]


### PR DESCRIPTION
The [previous hompage](https://ellie.behemehal.net) does not works anymore.

Also, [the project page of ellie-lang says](https://github.com/behemehal/Ellie-Language):
https://www.ellie-lang.org/