### PR TITLE
Add brood ECS.

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -105,6 +105,11 @@ source = "crates"
 categories = ["textrendering"]
 
 [[items]]
+name = "brood"
+source = "crates"
+categories = ["ecs"]
+
+[[items]]
 name = "building-blocks"
 source = "crates"
 categories = ["tools", "mesh"]


### PR DESCRIPTION
Adds [`brood`](https://crates.io/crates/brood) to the list of ECS crates.