### PR TITLE
Add apecs to ecs category

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -24,6 +24,11 @@ source = "crates"
 categories = ["networking"]
 
 [[items]]
+name = "apecs"
+source = "crates"
+categories = ["ecs"]
+
+[[items]]
 name = "arcana-engine/arcana"
 source = "github"
 categories = ["engines"]


### PR DESCRIPTION
Adds [apecs](https://crates.io/crates/apecs) to the ECS category.