### PR TITLE
Add vorbis_rs

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -1435,6 +1435,11 @@ source = "crates"
 categories = ["audio"]
 
 [[items]]
+name = "vorbis_rs"
+source = "crates"
+categories = ["audio"]
+
+[[items]]
 name = "voronator"
 source = "crates"
 categories = ["tools", "mesh"]


### PR DESCRIPTION
`vorbis_rs` is a new set of updated C FFI bindings for the Vorbis reference encoder patched with aoTuV and Lancer, providing performance improvements and, more subjectively, coding quality improvements.