### PR TITLE
Add gemini-engine

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -426,6 +426,11 @@ source = "crates"
 categories = ["math"]
 
 [[items]]
+name = "gemini-engine" 
+source = "crates"
+categories = ["2drendering", "3drendering", "engines"]
+
+[[items]]
 name = "gfx"
 source = "crates"
 categories = ["3drendering"]
@@ -1514,8 +1519,3 @@ categories = ["tools"]
 name = "ziyasal/natura"
 source = "github"
 categories = ["animation"]
-
-[[items]]
-name = "gemini-engine" 
-source = "crates"
-categories = ["2drendering", "3drendering", "engines"]

--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -1514,3 +1514,8 @@ categories = ["tools"]
 name = "ziyasal/natura"
 source = "github"
 categories = ["animation"]
+
+[[items]]
+name = "gemini-engine" 
+source = "crates"
+categories = ["2drendering", "3drendering", "engines"]


### PR DESCRIPTION
[gemini-engine](https://crates.io/crates/gemini-engine) is a monospaced ASCII rendering engine, capable of rendering 2D and 3D graphics in a terminal/console.