### PR TITLE
Add archive section to each page (fixes #485)

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -103,8 +103,20 @@ a {
     color: #767676;
 }
 
+.ui.card.archived {
+    background-color: #f8f8f9;
+}
+
 .ui.primary.button, .ui.primary.buttons .button {
     background-color: #1F7BC1;
+}
+
+.ui.container .ui.message {
+    margin: .875em .5em;
+
+    @media only screen and (max-width: 767px) {
+        margin: 2em 1em;
+    }
 }
 
 .nolist {

--- a/sass/_semantic.scss
+++ b/sass/_semantic.scss
@@ -20,7 +20,7 @@
 // @import 'semantic/form';
 @import 'semantic/grid';
 @import 'semantic/menu';
-//@import 'semantic/message';
+@import 'semantic/message';
 // @import 'semantic/table';
 // @import 'semantic/ad';
 @import 'semantic/card';

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -1,4 +1,4 @@
-{% macro info(item, section) %}
+{% macro info(item, section, archived=false) %}
 
 {% if item.name %}
     {% set name = item.name %}
@@ -43,7 +43,7 @@
     {% set primary_url = repository_url %}
 {% endif %}
 
-<li class="ui card">
+<li class="ui card{% if archived %} archived{% endif %}">
     {% if item.image %}
          {% if primary_url %}
             <a class="image" href="{{ primary_url }}">

--- a/templates/categories/page.html
+++ b/templates/categories/page.html
@@ -32,6 +32,22 @@
 </section>
 
 {# list all content #}
+
+{% set config = load_data(path = "content/" ~ section.path ~ "data.toml", format="toml") %}
+
+{% set crates = [] %}
+{% set archived = [] %}
+
+{% for item in config.items %}
+    {% if item.categories is containing(page.slug) %}
+        {% if item.archived %}
+            {% set_global archived = archived | concat(with=item) %}
+        {% else %}
+            {% set_global crates = crates | concat(with=item) %}
+        {% endif %}
+    {% endif %}
+{% endfor %}
+
 <section>
     <h2 class="ui horizontal divider small header">
         <a href="#{{ section.extra.plural | slugify }}" id="{{ section.extra.plural | slugify }}">
@@ -43,19 +59,39 @@
     <div class="ui vertical stripe">
         <div class="ui container">
             <ul class="ui stackable cards nolist {{ columns }}">
-                {% set config = load_data(path = "content/" ~ section.path ~ "data.toml", format="toml") %}
-
-                {% if config.items %}
-                    {% for item in config.items %}
-                        {% if item.categories is containing(page.slug) %}
-                            {{ category_macros::info(item=item, section=section) }}
-                        {% endif %}
-                    {% endfor %}
-                {% endif %}
+                {% for item in crates %}
+                    {{ category_macros::info(item=item, section=section) }}
+                {% endfor %}
             </ul>
         </div>
     </div>
 </section>
+
+{% if archived | length > 0 %}
+    <section>
+        <h2 class="ui horizontal divider small header">
+            <a href="#{{ section.extra.plural | slugify }}" id="{{ section.extra.plural | slugify }}">
+                <i class="bed icon big"></i>
+                Archived
+            </a>
+        </h2>
+
+        <div class="ui vertical stripe">
+            <div class="ui container">
+                <div class="ui message">
+                    <i class="info circle icon"></i>
+                    These {{ section.extra.plural }} are no longer maintained, but may still be of interest.
+                </div>
+
+                <ul class="ui stackable cards nolist {{ columns }}">
+                    {% for item in archived %}
+                        {{ category_macros::info(item=item, section=section, archived=true) }}
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+    </section>
+{% endif %}
 
 <section>
     <h2 class="ui horizontal divider small header">


### PR DESCRIPTION
Screenshot:

![](https://github.com/rust-gamedev/arewegameyet/assets/784533/3f56c07a-763f-4f6e-a100-b53a78f5ef52)

A few notes on the implementation:

* I've not actually gone through and marked any crates as archived in this PR - I figured that could be done seperately (as a rework of #542?)
* This should work for crates, games, and resources.
* If a category has no archived crates, the section is hidden.
* As discussed on the original issue, I wasn't sure what icon to use for the section - I didn't want to go for a thumbs down or a trashcan or anything like that, as that felt too negative. I ended up going for the 'bed' icon - the implication being the crates are asleep :p