### PR TITLE
Fix sorting of categories

### DIFF
--- a/templates/macros.html
+++ b/templates/macros.html
@@ -17,7 +17,7 @@
             <div class="ui four stackable cards">
                 {% set data = load_data(path="content/" ~ section.path ~ "data.toml") %}
 
-                {% for category in section.pages %}
+                {% for category in section.pages | sort(attribute="title") %}
                     {# This isn't very pretty/efficient, but it's about as good as we can do with Zola's current feature set #}
 
                     {% set_global count = 0 %}


### PR DESCRIPTION
At some point, the categories listed on the homepage stopped being sorted consistently (might have been after the last Zola update):

![image](https://github.com/rust-gamedev/arewegameyet/assets/784533/d8084ae8-2e10-47c5-8da2-416b61019ec6)

This PR enforces that they're always sorted alphabetically.