### PR TITLE
Add `clipline`

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -191,6 +191,11 @@ source = "crates"
 categories = ["audio"]
 
 [[items]]
+name = "clipline"
+source = "crates"
+categories = ["2drendering"]
+
+[[items]]
 name = "coffee"
 source = "crates"
 categories = ["engines"]


### PR DESCRIPTION
A line clipping and rasterization library, usable with `pixels`, `softbuffer` and similar crates.