### PR TITLE
Make GitHub stars badge style consistent

### DIFF
--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -143,7 +143,7 @@
                     <div class="item" aria-hidden="true">
                         <div class="content">
                             <a href="https://github.com/{{owner}}/{{name}}">
-                                <img src="https://img.shields.io/github/stars/{{owner}}/{{name}}" alt="Github Stars for {{ name }}">
+                                <img src="https://img.shields.io/github/stars/{{owner}}/{{name}}?style=flat" alt="Github Stars for {{ name }}">
                             </a>
                         </div>
                     </div>


### PR DESCRIPTION
I noticed after merging #587 that the stars badge defaults to a different style from all the others. For consistency, I think it's probably worth overriding.