### PR TITLE
Improve accessibility of badges

### DIFF
--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -6,13 +6,16 @@
 
 {% if item.source %}
     {% if item.source == 'crates' %}
-        {% set data = load_data(url = "https://crates.io/api/v1/crates/" ~ item.name ~ "?include=", format="json", headers=["User-Agent=arewegameyet (gamedev-wg@rust-lang.org)"]) %}
+        {% set data = load_data(url = "https://crates.io/api/v1/crates/" ~ item.name ~ "?include=downloads", format="json", headers=["User-Agent=arewegameyet (gamedev-wg@rust-lang.org)"]) %}
         {# human readable name #}
         {% set name = data.crate.name %}
         {# Github/Gitlab/Etc. repository #}
         {% set repository_url = data.crate.repository %}
         {% set crate_url = 'https://crates.io/crates/' ~ name %}
         {% set description = data.crate.description %}
+        {% set latest_version = data.crate.default_version %}
+        {% set downloads = data.crate.downloads %}
+        {% set recent_downloads = data.crate.recent_downloads %}
         {% if data.crate.homepage %}
             {% set homepage_url = data.crate.homepage %}
         {% endif %}
@@ -26,6 +29,8 @@
             {% set homepage_url = data.homepage %}
         {% endif %}
         {% set description = data.description %}
+        {% set stars = data.stargazers_count %}
+        {% set last_commit = data.pushed_at %}
     {% endif %}
 {% endif %}
 
@@ -113,44 +118,44 @@
                     <div class="item">
                         <div class="content">
                             <a href="https://crates.io/crates/{{name}}">
-                                <img src="https://img.shields.io/crates/v/{{name}}.svg?maxAge=2592000" alt="Crates.io link for {{ name }}">
+                                <img src="https://img.shields.io/crates/v/{{name}}.svg?maxAge=2592000" alt="Latest version: {{ latest_version }}">
                             </a>
                         </div>
                     </div>
-                    <div class="item" aria-hidden="true">
+                    <div class="item">
                         <div class="content">
                             <a href="https://crates.io/crates/{{name}}">
-                                <img src="https://img.shields.io/crates/d/{{name}}.svg?maxAge=2592000" alt="Download count for {{ name }}">
+                                <img src="https://img.shields.io/crates/d/{{name}}.svg?maxAge=2592000" alt="Downloads: {{ downloads }}">
                             </a>
                         </div>
                     </div>
-                    <div class="item" aria-hidden="true">
+                    <div class="item">
                         <div class="content">
                             <a href="https://crates.io/crates/{{name}}">
-                                <img src="https://img.shields.io/crates/dr/{{name}}.svg?maxAge=2592000" alt="Recent download count for {{ name }}">
+                                <img src="https://img.shields.io/crates/dr/{{name}}.svg?maxAge=2592000" alt="Recent downloads: {{ recent_downloads }}">
                             </a>
                         </div>
                     </div>
-                    <div class="item" aria-hidden="true">
+                    <div class="item">
                         <div class="content">
                             <a href="https://crates.io/crates/{{name}}">
-                                <img src="https://img.shields.io/crates/l/{{name}}.svg?maxAge=2592000" alt="License for {{ name }}">
+                                <img src="https://img.shields.io/crates/l/{{name}}.svg?maxAge=2592000" alt="View license for {{ name }}">
                             </a>
                         </div>
                     </div>
                 {% endif %}
                 {% if item.source and item.source == 'github' %}
-                    <div class="item" aria-hidden="true">
+                    <div class="item">
                         <div class="content">
                             <a href="https://github.com/{{owner}}/{{name}}">
-                                <img src="https://img.shields.io/github/stars/{{owner}}/{{name}}?style=flat" alt="Github Stars for {{ name }}">
+                                <img src="https://img.shields.io/github/stars/{{owner}}/{{name}}?style=flat" alt="Github Stars: {{ stars }}">
                             </a>
                         </div>
                     </div>
-                    <div class="item" aria-hidden="true">
+                    <div class="item">
                         <div class="content">
                             <a href="https://github.com/{{owner}}/{{name}}">
-                                <img src="https://img.shields.io/github/last-commit/{{owner}}/{{name}}" alt="Last commit date for {{ name }}">
+                                <img src="https://img.shields.io/github/last-commit/{{owner}}/{{name}}" alt="Last commit date: {{ last_commit | date }}">
                             </a>
                         </div>
                     </div>


### PR DESCRIPTION
It occurred to me while reviewing #587 that if you're using a screen reader, you don't get any of the information provided by the badges. This doesn't seem ideal, given that information is what you're likely to use to decide which crate is more actively updated!

This PR replaces the alt text for the badges with equivalent information sourced from the APIs, and removes the `aria-hidden` attribute so that screen readers won't ignore them.

This could also help with #580, as we now have the information we'd need to sort by.

I haven't added this functionality to the license badge (yet), as the Crates.io API doesn't make that super easy to obtain (you have to fetch all the crate versions, then pick the license from the one matching `latest_version`). I can think of three approachs to sort this:

* Just accept the larger Crates.io load (not ideal, don't want to get rate limited and/or make the Crates.io team mad at us).
* Grab the license from the GitHub API instead (this would also open up being able to have last commit date/star count for `crates` sourced items, but again, it might get us rate limited).
* Change the link URL to point directly at the license somehow (bit of a cop out, but at least it would make it easier to find).