### PR TITLE
Replace Shields.io with locally rendered data/badges

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -57,6 +57,14 @@
     margin-right: 0.5em;
 }
 
+.ui.label > .icon {
+    margin-right: 0.25em;
+}
+
+.ui.label > .detail {
+    margin-left: 0.5em;
+}
+
 @media only screen and (max-width: 991px) {
     .masthead .ui.menu a.item {
         display: none;

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -45,6 +45,11 @@
     height: 256px;
 }
 
+.ui.cards > .card > .content > .header:not(.ui), .ui.card > .content > .header:not(.ui) {
+    display: inline-block;
+    margin-bottom: 0;
+}
+
 .ui.card > .image > img, .ui.cards > .card > .image > img {
     object-fit: cover;
     width: 100%;

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -57,6 +57,14 @@
     margin-right: 0.5em;
 }
 
+ul.ui.horizontal.list {
+    margin: 0;
+}
+
+ul.ui.list li::before {
+    content: none;
+}
+
 .ui.label > .icon {
     margin-right: 0.25em;
 }

--- a/sass/_semantic.scss
+++ b/sass/_semantic.scss
@@ -8,7 +8,7 @@
 @import 'semantic/icon';
 @import 'semantic/image';
 // @import 'semantic/input';
-// @import 'semantic/label';
+@import 'semantic/label';
 @import 'semantic/list';
 //@import 'semantic/loader';
 //@import 'semantic/placeholder';

--- a/sass/semantic/_label.scss
+++ b/sass/semantic/_label.scss
@@ -351,7 +351,7 @@ a.ui.label {
 }
 .ui.card .image > .ui.ribbon.label,
 .ui.image > .ui.ribbon.label {
-  left: calc(--0.05rem - 1.2em);
+  left: calc(-0.05rem - 1.2em);
 }
 .ui.card .image > .ui[class*="right ribbon"].label,
 .ui.image > .ui[class*="right ribbon"].label {

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -28,7 +28,7 @@
     {% set description = data.description %}
     {% set repository_url = data.html_url %}
 
-    {% if data.license %}
+    {% if data.license and data.license.key != "other"  %}
         {% set license = data.license.name %}
     {% endif %}
     

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -131,7 +131,7 @@
         </div>
     </div>
     
-    {% if item.source or gitter_url %}
+    {% if item.source or repository_url or gitter_url %}
         <div class="extra content">
             <div class="ui horizontal list">
                 {% if gitter_url %}

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -54,7 +54,7 @@
 {% endif %}
 
 {% if repository_url and repository_url is containing("github.com/") %}
-    {% set repo_id = repository_url | split(pat="github.com/") | last | trim_end_matches(pat="/") %}
+    {% set repo_id = repository_url | split(pat="github.com/") | last | trim_end_matches(pat="/") | trim_end_matches(pat=".git") %}
 
     {% set data = load_data(url="https://api.github.com/repos/" ~ repo_id, headers=["Authorization=Bearer " ~ github_token], format="json", required=false) %}
     {% if data %}
@@ -62,7 +62,7 @@
         {% set last_activity = data.pushed_at %}
     {% endif %}
 {% elif repository_url and repository_url is containing("gitlab.com/") %}
-    {% set repo_id = repository_url | split(pat="gitlab.com/") | last  | trim_end_matches(pat="/") | urlencode_strict %}
+    {% set repo_id = repository_url | split(pat="gitlab.com/") | last  | trim_end_matches(pat="/") | trim_end_matches(pat=".git") | urlencode_strict %}
 
     {% set data = load_data(url="https://gitlab.com/api/v4/projects/" ~ repo_id, format="json", required=false) %}
     {% if data %}

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -1,36 +1,39 @@
 {% macro info(item, section, archived=false) %}
 
+{% set github_token = get_env(name="GITHUB_TOKEN") %}
+
 {% if item.name %}
     {% set name = item.name %}
 {% endif %}
 
-{% if item.source %}
-    {% if item.source == 'crates' %}
-        {% set data = load_data(url = "https://crates.io/api/v1/crates/" ~ item.name ~ "?include=downloads", format="json", headers=["User-Agent=arewegameyet (gamedev-wg@rust-lang.org)"]) %}
-        {# human readable name #}
-        {% set name = data.crate.name %}
-        {# Github/Gitlab/Etc. repository #}
-        {% set repository_url = data.crate.repository %}
-        {% set crate_url = 'https://crates.io/crates/' ~ name %}
-        {% set description = data.crate.description %}
-        {% set latest_version = data.crate.default_version %}
-        {% set downloads = data.crate.downloads %}
-        {% set recent_downloads = data.crate.recent_downloads %}
-        {% if data.crate.homepage %}
-            {% set homepage_url = data.crate.homepage %}
-        {% endif %}
-    {% elif item.source == 'github' %}
-        {% set data = load_data(url="https://api.github.com/repos/" ~ item.name, format="json") %}
-        {% set name = data.name %}
-        {% set repository_url = data.html_url %}
-        {# Org or User name #}
-        {% set owner = data.owner.login %}
-        {% if data.homepage != "" %}
-            {% set homepage_url = data.homepage %}
-        {% endif %}
-        {% set description = data.description %}
-        {% set stars = data.stargazers_count %}
-        {% set last_commit = data.pushed_at %}
+{% if item.source and item.source == 'crates' %}
+    {% set data = load_data(url = "https://crates.io/api/v1/crates/" ~ item.name ~ "?include=downloads,default_version", format="json", headers=["User-Agent=arewegameyet (gamedev-wg@rust-lang.org)"]) %}
+
+    {% set name = data.crate.name %}
+    {% set description = data.crate.description %}
+    {% set repository_url = data.crate.repository %}
+    {% set crate_url = 'https://crates.io/crates/' ~ name %}
+    {% set latest_version = data.crate.default_version %}
+    {% set downloads = data.crate.downloads %}
+    {% set recent_downloads = data.crate.recent_downloads %}
+    {% set license = data.versions | first | get(key="license") %}
+
+    {% if data.crate.homepage %}
+        {% set homepage_url = data.crate.homepage %}
+    {% endif %}
+{% elif item.source and item.source == 'github' %}
+    {% set data = load_data(url="https://api.github.com/repos/" ~ item.name, headers=["Authorization=Bearer " ~ github_token], format="json") %}
+    
+    {% set name = data.name %}
+    {% set description = data.description %}
+    {% set repository_url = data.html_url %}
+
+    {% if data.license %}
+        {% set license = data.license.name %}
+    {% endif %}
+    
+    {% if data.homepage %}
+        {% set homepage_url = data.homepage %}
     {% endif %}
 {% endif %}
 
@@ -50,6 +53,24 @@
     {% set primary_url = repository_url %}
 {% endif %}
 
+{% if repository_url and repository_url is containing("github.com/") %}
+    {% set repo_id = repository_url | split(pat="github.com/") | last %}
+
+    {% set data = load_data(url="https://api.github.com/repos/" ~ repo_id, headers=["Authorization=Bearer " ~ github_token], format="json", required=false) %}
+    {% if data %}
+        {% set stars = data.stargazers_count %}
+        {% set last_activity = data.pushed_at %}
+    {% endif %}
+{% elif repository_url and repository_url is containing("gitlab.com/") %}
+    {% set repo_id = repository_url | split(pat="gitlab.com/") | last | urlencode_strict %}
+
+    {% set data = load_data(url="https://gitlab.com/api/v4/projects/" ~ repo_id, format="json", required=false) %}
+    {% if data %}
+        {% set stars = data.star_count %}
+        {% set last_activity = data.last_activity_at %}
+    {% endif %}
+{% endif %}
+
 <li class="ui card{% if archived %} archived{% endif %}">
     {% if item.image %}
          {% if primary_url %}
@@ -66,28 +87,28 @@
     {% endif %}
 
     <div class="content">
-        <a href="#{{ name | slugify }}" id="{{ name | slugify }}" aria-label="Permanent link for {{ name }}">
-            <i class="right floated hashtag icon"></i>
+        <a class="right floated" href="#{{ name | slugify }}" id="{{ name | slugify }}" aria-label="Permanent link for {{ name }}">
+            <i class="hashtag icon" aria-hidden="true"></i>
         </a>
 
         {% if repository_url %}
-            <a href="{{ repository_url }}" aria-label="Github link for {{ name }}">
-                <i class="right floated github icon"></i>
+            <a class="right floated" href="{{ repository_url }}" aria-label="Github link for {{ name }}">
+                <i class="github icon" aria-hidden="true"></i>
             </a>
         {% endif %}
 
         {% if crate_url %}
-            <a href="{{ crate_url }}" aria-label="Crates.io link for {{ name }}">
-                <i class="right floated cube icon"></i>
+            <a class="right floated" href="{{ crate_url }}" aria-label="Crates.io link for {{ name }}">
+                <i class="cube icon" aria-hidden="true"></i>
             </a>
         {% endif %}
 
         {% if homepage_url %}
-            <a href="{{ homepage_url }}" aria-label="Website link for {{ name }}">
-                <i class="right floated home icon"></i>
+            <a class="right floated" href="{{ homepage_url }}" aria-label="Website link for {{ name }}">
+                <i class="home icon" aria-hidden="true"></i>
             </a>
         {% endif %}
-        
+
         <div class="header">
             {% if primary_url %}
                 <a href="{{ primary_url }}">{{ name }}</a>
@@ -112,60 +133,80 @@
     
     {% if item.source or gitter_url %}
         <div class="extra content">
-            
             <div class="ui horizontal list">
-                {% if item.source and item.source == 'crates' %}
-                    <div class="item">
-                        <div class="content">
-                            <a href="https://crates.io/crates/{{name}}">
-                                <img src="https://img.shields.io/crates/v/{{name}}.svg?maxAge=2592000" alt="Latest version: {{ latest_version }}">
-                            </a>
-                        </div>
-                    </div>
-                    <div class="item">
-                        <div class="content">
-                            <a href="https://crates.io/crates/{{name}}">
-                                <img src="https://img.shields.io/crates/d/{{name}}.svg?maxAge=2592000" alt="Downloads: {{ downloads }}">
-                            </a>
-                        </div>
-                    </div>
-                    <div class="item">
-                        <div class="content">
-                            <a href="https://crates.io/crates/{{name}}">
-                                <img src="https://img.shields.io/crates/dr/{{name}}.svg?maxAge=2592000" alt="Recent downloads: {{ recent_downloads }}">
-                            </a>
-                        </div>
-                    </div>
-                    <div class="item">
-                        <div class="content">
-                            <a href="https://crates.io/crates/{{name}}">
-                                <img src="https://img.shields.io/crates/l/{{name}}.svg?maxAge=2592000" alt="View license for {{ name }}">
-                            </a>
-                        </div>
-                    </div>
-                {% endif %}
-                {% if item.source and item.source == 'github' %}
-                    <div class="item">
-                        <div class="content">
-                            <a href="https://github.com/{{owner}}/{{name}}">
-                                <img src="https://img.shields.io/github/stars/{{owner}}/{{name}}?style=flat" alt="Github Stars: {{ stars }}">
-                            </a>
-                        </div>
-                    </div>
-                    <div class="item">
-                        <div class="content">
-                            <a href="https://github.com/{{owner}}/{{name}}">
-                                <img src="https://img.shields.io/github/last-commit/{{owner}}/{{name}}" alt="Last commit date: {{ last_commit | date }}">
-                            </a>
-                        </div>
-                    </div>
-                {% endif %}
                 {% if gitter_url %}
                     <div class="item">
                         <div class="content">
-                            <a href="{{ gitter_url }}" target="_blank">
-                                <img src="/assets/badges/chat.svg"/>
+                            <a class="ui blue label" href="{{ gitter_url }}" target="_blank">
+                                <i class="chat icon" aria-hidden="true"></i>
+                                Chat on Gitter
                             </a>
+                        </div>
+                    </div>
+                {% endif %}
+                {% if latest_version %}
+                    <div class="item">
+                        <div class="content">
+                            <div class="ui basic label">
+                                <i class="code icon" aria-hidden="true"></i>
+                                Latest version:
+                                <div class="detail">{{ latest_version }}</div>
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
+                {% if downloads %}
+                    <div class="item">
+                        <div class="content">
+                            <div class="ui basic label">
+                                <i class="download icon" aria-hidden="true"></i>
+                                Downloads:
+                                <div class="detail">{{ downloads | num_format }}</div>
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
+                {% if recent_downloads %}
+                    <div class="item">
+                        <div class="content">
+                            <div class="ui basic label">
+                                <i class="clock icon" aria-hidden="true"></i>
+                                Recent downloads:
+                                <div class="detail">{{ recent_downloads | num_format }}</div>
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
+                {% if license %}
+                    <div class="item">
+                        <div class="content">
+                            <div class="ui basic label">
+                                <i class="balance scale icon" aria-hidden="true"></i>
+                                License:
+                                <div class="detail">{{ license }}</div>
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
+                {% if stars %}
+                    <div class="item">
+                        <div class="content">
+                            <div class="ui basic label">
+                                <i class="star icon" aria-hidden="true"></i>
+                                Stars:
+                                <div class="detail">{{ stars }}</div>
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
+                {% if last_activity %}
+                    <div class="item">
+                        <div class="content">
+                            <div class="ui basic label">
+                                <i class="calendar icon" aria-hidden="true"></i>
+                                Last activity:
+                                <div class="detail">{{ last_activity | date(format="%Y-%m-%d") }}</div>
+                            </div>
                         </div>
                     </div>
                 {% endif %}

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -53,7 +53,9 @@
     {% set primary_url = repository_url %}
 {% endif %}
 
+{# Fetch repository stats #}
 {% if repository_url and repository_url is containing("github.com/") %}
+    {% set repo_icon = "github" %}
     {% set repo_id = repository_url | split(pat="github.com/") | last | trim_end_matches(pat="/") | trim_end_matches(pat=".git") %}
 
     {% set data = load_data(url="https://api.github.com/repos/" ~ repo_id, headers=["Authorization=Bearer " ~ github_token], format="json", required=false) %}
@@ -62,13 +64,16 @@
         {% set last_activity = data.pushed_at %}
     {% endif %}
 {% elif repository_url and repository_url is containing("gitlab.com/") %}
-    {% set repo_id = repository_url | split(pat="gitlab.com/") | last  | trim_end_matches(pat="/") | trim_end_matches(pat=".git") | urlencode_strict %}
+    {% set repo_icon = "gitlab" %}
+    {% set repo_id = repository_url | split(pat="gitlab.com/") | last | trim_end_matches(pat="/") | trim_end_matches(pat=".git") | urlencode_strict %}
 
     {% set data = load_data(url="https://gitlab.com/api/v4/projects/" ~ repo_id, format="json", required=false) %}
     {% if data %}
         {% set stars = data.star_count %}
         {% set last_activity = data.last_activity_at %}
     {% endif %}
+{% else %}
+    {% set repo_icon = "code" %}
 {% endif %}
 
 <li class="ui card{% if archived %} archived{% endif %}">
@@ -92,8 +97,8 @@
         </a>
 
         {% if repository_url %}
-            <a class="right floated" href="{{ repository_url }}" aria-label="Github link for {{ name }}">
-                <i class="github icon" aria-hidden="true"></i>
+            <a class="right floated" href="{{ repository_url }}" aria-label="Repository link for {{ name }}">
+                <i class="{{ repo_icon }} icon" aria-hidden="true"></i>
             </a>
         {% endif %}
 

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -194,7 +194,7 @@
                             <div class="ui basic label">
                                 <i class="star icon" aria-hidden="true"></i>
                                 Stars:
-                                <div class="detail">{{ stars }}</div>
+                                <div class="detail">{{ stars | num_format }}</div>
                             </div>
                         </div>
                     </div>

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -82,7 +82,7 @@
     {% endif %}
 {% endif %}
 
-<li class="ui card{% if archived %} archived{% endif %}" aria-label="{{ name }}">
+<li class="ui card{% if archived %} archived{% endif %}">
     {% if item.image %}
          {% if primary_url %}
             <a class="image" href="{{ primary_url }}">
@@ -98,6 +98,14 @@
     {% endif %}
 
     <div class="content">
+        <h3 class="header">
+            {% if primary_url %}
+                <a href="{{ primary_url }}">{{ name }}</a>
+            {% else %}
+                {{ name }}
+            {% endif %}
+        </h3>
+
         <a class="right floated" href="#{{ name | slugify }}" id="{{ name | slugify }}" aria-label="Permanent link for {{ name }}">
             <i class="hashtag icon" aria-hidden="true"></i>
         </a>
@@ -119,14 +127,6 @@
                 <i class="home icon" aria-hidden="true"></i>
             </a>
         {% endif %}
-
-        <div class="header">
-            {% if primary_url %}
-                <a href="{{ primary_url }}">{{ name }}</a>
-            {% else %}
-                {{ name }}
-            {% endif %}
-        </div>
 
         <div class="meta">
             {% for category in item.categories %}

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -72,8 +72,14 @@
         {% set stars = data.star_count %}
         {% set last_activity = data.last_activity_at %}
     {% endif %}
-{% else %}
-    {% set repo_icon = "code" %}
+{% elif repository_url and repository_url is containing("gitea.com/") %}
+    {% set repo_id = repository_url | split(pat="gitea.com/") | last | trim_end_matches(pat="/") | trim_end_matches(pat=".git") %}
+
+    {% set data = load_data(url="https://gitea.com/api/v1/repos/" ~ repo_id, format="json", required=false) %}
+    {% if data %}
+        {% set stars = data.stars_count %}
+        {% set last_activity = data.updated_at %}
+    {% endif %}
 {% endif %}
 
 <li class="ui card{% if archived %} archived{% endif %}" aria-label="{{ name }}">
@@ -98,7 +104,7 @@
 
         {% if repository_url %}
             <a class="right floated" href="{{ repository_url }}" aria-label="Repository link for {{ name }}">
-                <i class="{{ repo_icon }} icon" aria-hidden="true"></i>
+                <i class="{{ repo_icon | default(value="code") }} icon" aria-hidden="true"></i>
             </a>
         {% endif %}
 

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -76,7 +76,7 @@
     {% set repo_icon = "code" %}
 {% endif %}
 
-<li class="ui card{% if archived %} archived{% endif %}">
+<li class="ui card{% if archived %} archived{% endif %}" aria-label="{{ name }}">
     {% if item.image %}
          {% if primary_url %}
             <a class="image" href="{{ primary_url }}">
@@ -138,19 +138,19 @@
     
     {% if item.source or repository_url or gitter_url %}
         <div class="extra content">
-            <div class="ui horizontal list">
+            <ul class="ui horizontal list">
                 {% if gitter_url %}
-                    <div class="item">
+                    <li class="item">
                         <div class="content">
                             <a class="ui blue label" href="{{ gitter_url }}" target="_blank">
                                 <i class="chat icon" aria-hidden="true"></i>
                                 Chat on Gitter
                             </a>
                         </div>
-                    </div>
+                    </li>
                 {% endif %}
                 {% if latest_version %}
-                    <div class="item">
+                    <li class="item">
                         <div class="content">
                             <div class="ui basic label">
                                 <i class="code icon" aria-hidden="true"></i>
@@ -158,10 +158,10 @@
                                 <div class="detail">{{ latest_version }}</div>
                             </div>
                         </div>
-                    </div>
+                    </li>
                 {% endif %}
                 {% if downloads %}
-                    <div class="item">
+                    <li class="item">
                         <div class="content">
                             <div class="ui basic label">
                                 <i class="download icon" aria-hidden="true"></i>
@@ -169,10 +169,10 @@
                                 <div class="detail">{{ downloads | num_format }}</div>
                             </div>
                         </div>
-                    </div>
+                    </li>
                 {% endif %}
                 {% if recent_downloads %}
-                    <div class="item">
+                    <li class="item">
                         <div class="content">
                             <div class="ui basic label">
                                 <i class="clock icon" aria-hidden="true"></i>
@@ -180,10 +180,10 @@
                                 <div class="detail">{{ recent_downloads | num_format }}</div>
                             </div>
                         </div>
-                    </div>
+                    </li>
                 {% endif %}
                 {% if license %}
-                    <div class="item">
+                    <li class="item">
                         <div class="content">
                             <div class="ui basic label">
                                 <i class="balance scale icon" aria-hidden="true"></i>
@@ -191,10 +191,10 @@
                                 <div class="detail">{{ license }}</div>
                             </div>
                         </div>
-                    </div>
+                    </li>
                 {% endif %}
                 {% if stars %}
-                    <div class="item">
+                    <li class="item">
                         <div class="content">
                             <div class="ui basic label">
                                 <i class="star icon" aria-hidden="true"></i>
@@ -202,10 +202,10 @@
                                 <div class="detail">{{ stars | num_format }}</div>
                             </div>
                         </div>
-                    </div>
+                    </li>
                 {% endif %}
                 {% if last_activity %}
-                    <div class="item">
+                    <li class="item">
                         <div class="content">
                             <div class="ui basic label">
                                 <i class="calendar icon" aria-hidden="true"></i>
@@ -213,9 +213,9 @@
                                 <div class="detail">{{ last_activity | date(format="%Y-%m-%d") }}</div>
                             </div>
                         </div>
-                    </div>
+                    </li>
                 {% endif %}
-            </div>
+            </ul>
         </div>
     {% endif %}
 </li>

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -216,7 +216,7 @@
                             <div class="ui basic label">
                                 <i class="calendar icon" aria-hidden="true"></i>
                                 Last activity:
-                                <div class="detail">{{ last_activity | date(format="%Y-%m-%d") }}</div>
+                                <div class="detail">{{ last_activity | date }}</div>
                             </div>
                         </div>
                     </li>

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -54,7 +54,7 @@
 {% endif %}
 
 {% if repository_url and repository_url is containing("github.com/") %}
-    {% set repo_id = repository_url | split(pat="github.com/") | last %}
+    {% set repo_id = repository_url | split(pat="github.com/") | last | trim_end_matches(pat="/") %}
 
     {% set data = load_data(url="https://api.github.com/repos/" ~ repo_id, headers=["Authorization=Bearer " ~ github_token], format="json", required=false) %}
     {% if data %}
@@ -62,7 +62,7 @@
         {% set last_activity = data.pushed_at %}
     {% endif %}
 {% elif repository_url and repository_url is containing("gitlab.com/") %}
-    {% set repo_id = repository_url | split(pat="gitlab.com/") | last | urlencode_strict %}
+    {% set repo_id = repository_url | split(pat="gitlab.com/") | last  | trim_end_matches(pat="/") | urlencode_strict %}
 
     {% set data = load_data(url="https://gitlab.com/api/v4/projects/" ~ repo_id, format="json", required=false) %}
     {% if data %}

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -6,13 +6,16 @@
 
 {% if item.source %}
     {% if item.source == 'crates' %}
-        {% set data = load_data(url = "https://crates.io/api/v1/crates/" ~ item.name ~ "?include=", format="json", headers=["User-Agent=arewegameyet (gamedev-wg@rust-lang.org)"]) %}
+        {% set data = load_data(url = "https://crates.io/api/v1/crates/" ~ item.name ~ "?include=downloads", format="json", headers=["User-Agent=arewegameyet (gamedev-wg@rust-lang.org)"]) %}
         {# human readable name #}
         {% set name = data.crate.name %}
         {# Github/Gitlab/Etc. repository #}
         {% set repository_url = data.crate.repository %}
         {% set crate_url = 'https://crates.io/crates/' ~ name %}
         {% set description = data.crate.description %}
+        {% set latest_version = data.crate.default_version %}
+        {% set downloads = data.crate.downloads %}
+        {% set recent_downloads = data.crate.recent_downloads %}
         {% if data.crate.homepage %}
             {% set homepage_url = data.crate.homepage %}
         {% endif %}
@@ -26,6 +29,8 @@
             {% set homepage_url = data.homepage %}
         {% endif %}
         {% set description = data.description %}
+        {% set stars = data.stargazers_count %}
+        {% set last_commit = data.pushed_at %}
     {% endif %}
 {% endif %}
 
@@ -113,44 +118,44 @@
                     <div class="item">
                         <div class="content">
                             <a href="https://crates.io/crates/{{name}}">
-                                <img src="https://img.shields.io/crates/v/{{name}}.svg?maxAge=2592000" alt="Crates.io link for {{ name }}">
+                                <img src="https://img.shields.io/crates/v/{{name}}.svg?maxAge=2592000" alt="Latest version: {{ latest_version }}">
                             </a>
                         </div>
                     </div>
-                    <div class="item" aria-hidden="true">
+                    <div class="item">
                         <div class="content">
                             <a href="https://crates.io/crates/{{name}}">
-                                <img src="https://img.shields.io/crates/d/{{name}}.svg?maxAge=2592000" alt="Download count for {{ name }}">
+                                <img src="https://img.shields.io/crates/d/{{name}}.svg?maxAge=2592000" alt="Downloads: {{ downloads }}">
                             </a>
                         </div>
                     </div>
-                    <div class="item" aria-hidden="true">
+                    <div class="item">
                         <div class="content">
                             <a href="https://crates.io/crates/{{name}}">
-                                <img src="https://img.shields.io/crates/dr/{{name}}.svg?maxAge=2592000" alt="Recent download count for {{ name }}">
+                                <img src="https://img.shields.io/crates/dr/{{name}}.svg?maxAge=2592000" alt="Recent downloads: {{ recent_downloads }}">
                             </a>
                         </div>
                     </div>
-                    <div class="item" aria-hidden="true">
+                    <div class="item">
                         <div class="content">
                             <a href="https://crates.io/crates/{{name}}">
-                                <img src="https://img.shields.io/crates/l/{{name}}.svg?maxAge=2592000" alt="License for {{ name }}">
+                                <img src="https://img.shields.io/crates/l/{{name}}.svg?maxAge=2592000" alt="View license for {{ name }}">
                             </a>
                         </div>
                     </div>
                 {% endif %}
                 {% if item.source and item.source == 'github' %}
-                    <div class="item" aria-hidden="true">
+                    <div class="item">
                         <div class="content">
                             <a href="https://github.com/{{owner}}/{{name}}">
-                                <img src="https://img.shields.io/github/stars/{{owner}}/{{name}}?style=flat" alt="Github Stars for {{ name }}">
+                                <img src="https://img.shields.io/github/stars/{{owner}}/{{name}}?style=flat" alt="Github Stars: {{ stars }}">
                             </a>
                         </div>
                     </div>
-                    <div class="item" aria-hidden="true">
+                    <div class="item">
                         <div class="content">
                             <a href="https://github.com/{{owner}}/{{name}}">
-                                <img src="https://img.shields.io/github/last-commit/{{owner}}/{{name}}" alt="Last commit date for {{ name }}">
+                                <img src="https://img.shields.io/github/last-commit/{{owner}}/{{name}}" alt="Last commit date: {{ last_commit | date }}">
                             </a>
                         </div>
                     </div>

--- a/templates/categories/page.html
+++ b/templates/categories/page.html
@@ -23,7 +23,7 @@
 {# Heading #}
 <section class="ui vertical stripe">
     <h1 class="ui center aligned icon header">
-        <i class="circular icon {{ section.extra.icon }}"></i>
+        <i class="circular icon {{ section.extra.icon }}" aria-hidden="true"></i>
         {{ page.title }}
     </h1>
     <div class="ui text container">
@@ -51,7 +51,7 @@
 <section>
     <h2 class="ui horizontal divider small header">
         <a href="#{{ section.extra.plural | slugify }}" id="{{ section.extra.plural | slugify }}">
-            <i class="list icon big"></i>
+            <i class="list icon big" aria-hidden="true"></i>
             {{ section.extra.plural | title }}
         </a>
     </h2>
@@ -71,7 +71,7 @@
     <section>
         <h2 class="ui horizontal divider small header">
             <a href="#{{ section.extra.plural | slugify }}" id="{{ section.extra.plural | slugify }}">
-                <i class="bed icon big"></i>
+                <i class="bed icon big" aria-hidden="true"></i>
                 Archived
             </a>
         </h2>
@@ -79,7 +79,7 @@
         <div class="ui vertical stripe">
             <div class="ui container">
                 <div class="ui message">
-                    <i class="info circle icon"></i>
+                    <i class="info circle icon" aria-hidden="true"></i>
                     These {{ section.extra.plural }} are no longer maintained, but may still be of interest.
                 </div>
 
@@ -96,7 +96,7 @@
 <section>
     <h2 class="ui horizontal divider small header">
         <a href="#contribute" id="contribute">
-            <i class="chat icon big"></i>
+            <i class="chat icon big" aria-hidden="true"></i>
             Contribute
         </a>
     </h2>

--- a/templates/master.html
+++ b/templates/master.html
@@ -106,7 +106,13 @@
                     </div>
                     <div class="ten wide column">
                         <h4 class="ui inverted header">Arewegameyet?</h4>
-                        <p><a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</p>
+                        <p>
+                            <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a>
+                            <br />
+                            This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+                            <br />
+                            Page generated at {{ now() | date(format="%Y-%m-%d %H:%M") }}.
+                        </p>
                     </div>
                     <div class="three wide column">
                         <h4 class="ui inverted header">Get involved</h4>


### PR DESCRIPTION
Currently, data like download counts and licenses is displayed by embedding [Shields.io](https://shields.io/) badges as image tags. This PR (which is an extension of #589) replaces these entirely with data fetched directly from Crates.io/GitHub/GitLab.

There's two pretty big benefits to doing this:

* It makes the data more accessible to people who are using screen readers (we have no way of providing any meaningful alt text for the existing badges, as Shields.io doesn't provide any way of accessing the underlying data).
* It unlocks the possibillity of adding (client-side) sorting functionality later down the line.
    * This has been requested numerous times: #580, #330

However, there are also some tradeoffs:

* The data will no longer be 100% up to date, as it'll only get fetched when the site re-renders.
    * This is done once a week, as well as when PRs are merged, though - so it should never get *too* stale.
* The site now takes a bit longer to build (1 minute on CI, as opposed to 30 seconds).
* Due to the extra requests to GitHub, we now have to provide a token to avoid getting rate-limited.
    * In fairness, this would have started happening as soon as we had more than 60 items with `source = "github"` anyway - the unauthenticated rate limit is very low!
    * GitHub Actions provides a token for every CI build anyway, but you'd have to provide one yourself if you're building locally.

I personally think these trade-offs are worth it (assuming I can get around to implementing the sorting functionality later!), but I'd be interested to get some feedback from the community on whether they think this is the right direction.

Here's what the new UI looks like (see the [live page](https://arewegameyet.rs/ecosystem/3drendering/) for comparison):

![image](https://github.com/user-attachments/assets/18e9585a-3bcc-43b0-9439-d71c49a903bc)

(the top three items there use the `crates` source, the last one uses the `github` source)