### PR TITLE
Add sdl3 to content

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -1324,6 +1324,11 @@ source = "crates"
 categories = ["2drendering", "audio", "engines", "textrendering", "input", "windowing"]
 
 [[items]]
+name = "sdl3"
+source = "crates"
+categories = ["2drendering", "audio", "engines", "textrendering", "input", "windowing"]
+
+[[items]]
 name = "sfml"
 source = "crates"
 categories = ["2drendering", "engines"]

--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -1326,7 +1326,7 @@ categories = ["2drendering", "audio", "engines", "textrendering", "input", "wind
 [[items]]
 name = "sdl3"
 source = "crates"
-categories = ["2drendering", "audio", "engines", "textrendering", "input", "windowing"]
+categories = ["2drendering", "audio", "engines", "3drendering", "input", "windowing"]
 
 [[items]]
 name = "sfml"


### PR DESCRIPTION
Adds the sdl3 crate to content/ecosystem/data.toml. This is my first time contributing here so I'm entirely sure if this is all that needs to be done, so let me know if there's anything else I should do