### PR TITLE
Fix curator card alignment

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -45,7 +45,7 @@
     height: 256px;
 }
 
-.ui.cards > .card > .content > .header:not(.ui), .ui.card > .content > .header:not(.ui) {
+.ui.cards > .card > .content > .header:not(.ui, .center.aligned), .ui.card > .content > .header:not(.ui, .center.aligned) {
     display: inline-block;
     margin-bottom: 0;
 }


### PR DESCRIPTION
The last PR inadventantly broke the alignment on the headings for the curator cards:

![image](https://github.com/user-attachments/assets/4bfaf91f-9382-4386-97e8-2ab593d5a4bb)
