### PR TITLE
Add sorting functionality to category pages

### DIFF
--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -137,6 +137,10 @@ ul.ui.list li::before {
     .card-grid.three, .card-grid.four {
         grid-template-columns: 1fr;
     }
+
+    #sort-menu {
+        width: 100%;
+    }
 }
 
 /* Colors overridden to avoid inaccessible contrast levels */

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -78,6 +78,10 @@ ul.ui.list li::before {
     margin-left: 0.5em;
 }
 
+#sort-menu {
+    margin-bottom: 1em;
+}
+
 @media only screen and (max-width: 991px) {
     .masthead .ui.menu a.item {
         display: none;

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -100,7 +100,8 @@ ul.ui.list li::before {
     margin-left: 0.5em;
 }
 
-#sort-menu {
+.crates-toolbar {
+    text-align: right;
     margin-bottom: 1.5em;
 }
 

--- a/sass/_extra.scss
+++ b/sass/_extra.scss
@@ -41,16 +41,38 @@
     padding: 5em 0em;
 }
 
+// This is a replacement for Semantic UI's .cards class, using CSS Grid
+// instead of relying on negative margins for layout.
+.card-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.5em;
+    margin: 0;
+}
+
+.card-grid.three {
+    grid-template-columns: repeat(3, 1fr);
+}
+
+.card-grid.four {
+    grid-template-columns: repeat(4, 1fr);
+}
+
+.card-grid .ui.card {
+    width: 100%;
+    margin: 0;
+}
+
 .ui.card .image {
     height: 256px;
 }
 
-.ui.cards > .card > .content > .header:not(.ui, .center.aligned), .ui.card > .content > .header:not(.ui, .center.aligned) {
+.ui.card > .content > .header:not(.ui, .center.aligned) {
     display: inline-block;
     margin-bottom: 0;
 }
 
-.ui.card > .image > img, .ui.cards > .card > .image > img {
+.ui.card > .image > img {
     object-fit: cover;
     width: 100%;
     height: 100%;
@@ -79,7 +101,7 @@ ul.ui.list li::before {
 }
 
 #sort-menu {
-    margin-bottom: 1em;
+    margin-bottom: 1.5em;
 }
 
 @media only screen and (max-width: 991px) {
@@ -111,6 +133,10 @@ ul.ui.list li::before {
     .vertical.stripe .text.container p {
         font-size: 1.1em;
     }
+
+    .card-grid.three, .card-grid.four {
+        grid-template-columns: 1fr;
+    }
 }
 
 /* Colors overridden to avoid inaccessible contrast levels */
@@ -120,11 +146,8 @@ a {
 }
 
 .ui.card > .extra,
-.ui.cards > .card > .extra,
 .ui.card .meta,
-.ui.cards > .card .meta,
-.ui.card .meta > a:not(.ui),
-.ui.cards > .card .meta > a:not(.ui) {
+.ui.card .meta > a:not(.ui) {
     color: #767676;
 }
 

--- a/sass/_semantic.scss
+++ b/sass/_semantic.scss
@@ -31,7 +31,7 @@
 // @import 'semantic/accordion';
 // @import 'semantic/checkbox';
 // @import 'semantic/dimmer';
-// @import 'semantic/dropdown';
+@import 'semantic/dropdown';
 //@import 'semantic/embed';
 //@import 'semantic/video';
 // @import 'semantic/modal';

--- a/static/assets/js/sortCrates.js
+++ b/static/assets/js/sortCrates.js
@@ -1,5 +1,5 @@
 function sortCrates(attribute, numeric, ascending) {
-    var section = $("#crates-section .cards");
+    var section = $("#crates-section .card-grid");
     var cards = section.children(".card");
 
     var default_value = numeric ? 0 : "";

--- a/static/assets/js/sortCrates.js
+++ b/static/assets/js/sortCrates.js
@@ -1,0 +1,42 @@
+function sortCrates(attribute, numeric, ascending) {
+    var section = $("#crates-section .cards");
+    var cards = section.children(".card");
+
+    var default_value = numeric ? 0 : "";
+
+    cards.sort(function (a, b) {
+        var aAttr = a.getAttribute(attribute) || default_value;
+        var bAttr = b.getAttribute(attribute) || default_value;
+
+        if (numeric) {
+            aAttr = parseInt(aAttr);
+            bAttr = parseInt(bAttr);
+        } else {
+            aAttr = aAttr.toUpperCase();
+            bAttr = bAttr.toUpperCase();
+        }
+
+        if (aAttr > bAttr) {
+            return ascending ? 1 : -1;
+        } else if (aAttr < bAttr) {
+            return ascending ? -1 : 1;
+        } else {
+            return 0;
+        }
+    });
+
+    cards.detach().appendTo(section);
+}
+
+$(document).ready(function () {
+    var sortDropdown = $("#sort-menu");
+
+    sortDropdown.dropdown({
+        onChange: function (value, text, selected) {
+            var type = selected[0].getAttribute("data-type");
+            var order = selected[0].getAttribute("data-order");
+
+            sortCrates(value, type == "num", order == "asc");
+        },
+    });
+});

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -82,7 +82,7 @@
     {% endif %}
 {% endif %}
 
-<li class="ui card{% if archived %} archived{% endif %}" data-name="{{ name }}"{% if downloads %} data-downloads="{{ downloads }}"{%endif%}{% if recent_downloads %} data-recent="{{ recent_downloads }}"{% endif %}{% if stars %} data-stars="{{ stars }}"{% endif %}{% if last_activity %} data-activity="{{ last_activity }}"{% endif %}>
+<li {% if archived %}class="ui card archived"{% else %}class="ui card" data-name="{{ name }}"{% if downloads %} data-downloads="{{ downloads }}"{%endif%}{% if recent_downloads %} data-recent="{{ recent_downloads }}"{% endif %}{% if stars %} data-stars="{{ stars }}"{% endif %}{% if last_activity %} data-activity="{{ last_activity }}"{% endif %}{% endif %}>
     {% if item.image %}
          {% if primary_url %}
             <a class="image" href="{{ primary_url }}">

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -82,7 +82,7 @@
     {% endif %}
 {% endif %}
 
-<li class="ui card{% if archived %} archived{% endif %}">
+<li class="ui card{% if archived %} archived{% endif %}" data-name="{{ name }}"{% if downloads %} data-downloads="{{ downloads }}"{%endif%}{% if recent_downloads %} data-recent="{{ recent_downloads }}"{% endif %}{% if license %} data-license="{{ license }}"{% endif %}{% if stars %} data-stars="{{ stars }}"{% endif %}{% if last_activity %} data-activity="{{ last_activity }}"{% endif %}>
     {% if item.image %}
          {% if primary_url %}
             <a class="image" href="{{ primary_url }}">

--- a/templates/categories/macros.html
+++ b/templates/categories/macros.html
@@ -82,7 +82,7 @@
     {% endif %}
 {% endif %}
 
-<li class="ui card{% if archived %} archived{% endif %}" data-name="{{ name }}"{% if downloads %} data-downloads="{{ downloads }}"{%endif%}{% if recent_downloads %} data-recent="{{ recent_downloads }}"{% endif %}{% if license %} data-license="{{ license }}"{% endif %}{% if stars %} data-stars="{{ stars }}"{% endif %}{% if last_activity %} data-activity="{{ last_activity }}"{% endif %}>
+<li class="ui card{% if archived %} archived{% endif %}" data-name="{{ name }}"{% if downloads %} data-downloads="{{ downloads }}"{%endif%}{% if recent_downloads %} data-recent="{{ recent_downloads }}"{% endif %}{% if stars %} data-stars="{{ stars }}"{% endif %}{% if last_activity %} data-activity="{{ last_activity }}"{% endif %}>
     {% if item.image %}
          {% if primary_url %}
             <a class="image" href="{{ primary_url }}">

--- a/templates/categories/page.html
+++ b/templates/categories/page.html
@@ -48,7 +48,7 @@
     {% endif %}
 {% endfor %}
 
-<section>
+<section id="crates-section">
     <h2 class="ui horizontal divider small header">
         <a href="#{{ section.extra.plural | slugify }}" id="{{ section.extra.plural | slugify }}">
             <i class="list icon big" aria-hidden="true"></i>
@@ -58,6 +58,24 @@
 
     <div class="ui vertical stripe">
         <div class="ui container">
+            <div id="sort-menu" class="ui dropdown icon selection">
+                <i class="sort amount down icon" aria-hidden="true"></i>
+                <span class="text">Sort by A-Z</span>
+                <i class="dropdown icon" aria-hidden="true"></i>
+
+                <ul class="menu">
+                    <li class="item" data-value="data-name" data-order="asc">Sort by A-Z</li>
+                    <li class="item" data-value="data-name">Sort by Z-A</li>
+                    
+                    {% if section.extra.plural == "crates" %}
+                        <li class="item" data-value="data-downloads" data-type="num">Sort by Downloads</li>
+                        <li class="item" data-value="data-recent" data-type="num">Sort by Recent Downloads</li>
+                        <li class="item" data-value="data-stars" data-type="num">Sort by Stars</li>
+                        <li class="item" data-value="data-activity">Sort by Last Activity</li>
+                    {% endif %}
+                </ul>
+            </div>
+
             <ul class="ui stackable cards nolist {{ columns }}">
                 {% for item in crates %}
                     {{ category_macros::info(item=item, section=section) }}
@@ -116,3 +134,8 @@
     </div>
 </section>
 {% endblock content %}
+
+{% block footer %}
+    <script src="/assets/semantic/js/dropdown.min.js"></script>
+    <script src="/assets/js/sortCrates.js"></script>
+{% endblock %}

--- a/templates/categories/page.html
+++ b/templates/categories/page.html
@@ -66,7 +66,7 @@
                 <ul class="menu">
                     <li class="item" data-value="data-name" data-order="asc">Sort by A-Z</li>
                     <li class="item" data-value="data-name">Sort by Z-A</li>
-                    
+
                     {% if section.extra.plural == "crates" %}
                         <li class="item" data-value="data-downloads" data-type="num">Sort by Downloads</li>
                         <li class="item" data-value="data-recent" data-type="num">Sort by Recent Downloads</li>
@@ -76,7 +76,7 @@
                 </ul>
             </div>
 
-            <ul class="ui stackable cards nolist {{ columns }}">
+            <ul class="ui card-grid nolist {{ columns }}">
                 {% for item in crates %}
                     {{ category_macros::info(item=item, section=section) }}
                 {% endfor %}
@@ -101,7 +101,7 @@
                     These {{ section.extra.plural }} are no longer maintained, but may still be of interest.
                 </div>
 
-                <ul class="ui stackable cards nolist {{ columns }}">
+                <ul class="ui card-grid nolist {{ columns }}">
                     {% for item in archived %}
                         {{ category_macros::info(item=item, section=section, archived=true) }}
                     {% endfor %}

--- a/templates/categories/page.html
+++ b/templates/categories/page.html
@@ -58,22 +58,24 @@
 
     <div class="ui vertical stripe">
         <div class="ui container">
-            <div id="sort-menu" class="ui dropdown icon selection">
-                <i class="sort amount down icon" aria-hidden="true"></i>
-                <span class="text">Sort by A-Z</span>
-                <i class="dropdown icon" aria-hidden="true"></i>
+            <div class="crates-toolbar">
+                <div id="sort-menu" class="ui dropdown icon selection">
+                    <i class="sort amount down icon" aria-hidden="true"></i>
+                    <span class="text">Sort by A-Z</span>
+                    <i class="dropdown icon" aria-hidden="true"></i>
 
-                <ul class="menu">
-                    <li class="item" data-value="data-name" data-order="asc">Sort by A-Z</li>
-                    <li class="item" data-value="data-name">Sort by Z-A</li>
+                    <ul class="menu">
+                        <li class="item" data-value="data-name" data-order="asc">Sort by A-Z</li>
+                        <li class="item" data-value="data-name">Sort by Z-A</li>
 
-                    {% if section.extra.plural == "crates" %}
-                        <li class="item" data-value="data-downloads" data-type="num">Sort by Downloads</li>
-                        <li class="item" data-value="data-recent" data-type="num">Sort by Recent Downloads</li>
-                        <li class="item" data-value="data-stars" data-type="num">Sort by Stars</li>
-                        <li class="item" data-value="data-activity">Sort by Last Activity</li>
-                    {% endif %}
-                </ul>
+                        {% if section.extra.plural == "crates" %}
+                            <li class="item" data-value="data-downloads" data-type="num">Sort by Downloads</li>
+                            <li class="item" data-value="data-recent" data-type="num">Sort by Recent Downloads</li>
+                            <li class="item" data-value="data-stars" data-type="num">Sort by Stars</li>
+                            <li class="item" data-value="data-activity">Sort by Last Activity</li>
+                        {% endif %}
+                    </ul>
+                </div>
             </div>
 
             <ul class="ui card-grid nolist {{ columns }}">

--- a/templates/index.html
+++ b/templates/index.html
@@ -114,7 +114,7 @@
         </div>
 
         <div class="ui container">
-            <div class="ui three stackable cards">
+            <div class="ui three card-grid">
                 {% set data = load_data(path="content/contributors/data.toml") %}
                 {{ macros::contributors(contributors=data.contributors) }} 
 

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -14,7 +14,7 @@
         {% endif %}
 
         <div class="ui container">
-            <div class="ui four stackable cards">
+            <div class="ui four card-grid">
                 {% set data = load_data(path="content/" ~ section.path ~ "data.toml") %}
 
                 {% for category in section.pages | sort(attribute="title") %}


### PR DESCRIPTION
This PR adds a dropdown to category pages, allowing the crates to be sorted in various ways:

https://github.com/user-attachments/assets/bf84b62e-1805-45a7-baed-e98b14949fb8

I originally intended to use a pre-made library for this, but all the ones I could find either:

* were way too huge/complex
* only worked with tables
* only worked with JS frameworks like React

Since we're already using jQuery for other parts of the site, I decided to just take the old school approach and write some JS myself. It seems fairly snappy on desktop, though I need to give it a try on mobile too.

---

I also found while working on this that Semantic UI's `.cards` class (which is used to create the columns on the homepage/game categories) is an _absolute nightmare_ - it uses negative margins for everything, which breaks the layout in strange ways if you try to put any other UI near it 🙃

To get around this, I ended up replacing it with a new `.card-grid` class, which uses CSS Grid to create the columns. This feature is [supported in 97% of browsers at this point](https://caniuse.com/css-grid).

---

**I would appreciate feedback on the UI, and whether there are other sort options that should be available!**

I did originally have the option to sort by license, but the license info is a little too inconsistent for that to work (e.g. some repos have `MIT and Apache`, some have `Apache and MIT`).