### PR TITLE
Move Amethyst to archived section

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -25,6 +25,7 @@ categories = ["audio"]
 name = "amethyst"
 source = "crates"
 categories = ["engines"]
+archived = true
 
 [[items]]
 name = "amethyst_network"


### PR DESCRIPTION
It's been archived on GitHub since 2022 and no longer compiles on stable Rust, so I think this is probably overdue.