### PR TITLE
Add audionimbus to content

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -78,6 +78,11 @@ source = "crates"
 categories = ["tools"]
 
 [[items]]
+name = "audionimbus"
+source = "crates"
+categories = ["audio"]
+
+[[items]]
 name = "audir"
 source = "crates"
 categories = ["audio"]


### PR DESCRIPTION
This PR adds an entry for [`audionimbus`](https://github.com/MaxenceMaire/audionimbus/tree/master/audionimbus), a Rust wrapper around [Steam Audio](https://valvesoftware.github.io/steam-audio/).

It provides spatial audio capabilities with realistic occlusion, reverb, and HRTF effects, accounting for physical attributes and scene geometry.