### PR TITLE
Add russimp into create catalog

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -1293,6 +1293,11 @@ source = "crates"
 categories = ["scripting"]
 
 [[items]]
+name = "russimp"
+source = "crates"
+categories = ["3dformatloaders"]
+
+[[items]]
 name = "Rust-GPU/rust-gpu"
 source = "github"
 categories = ["shader"]


### PR DESCRIPTION
russimp is a rust bindings to `assimp`, a very popular 3d asset import library written in C/C++, which is leveraged by a number of game engines (like o3de). 