### PR TITLE
Update to Zola 0.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BASE_URL: https://github.com/getzola/zola/releases/download
-      VERS: v0.19.0
+      VERS: v0.20.0
       ARCH: x86_64-unknown-linux-gnu
       # https://github.com/crazy-max/ghaction-github-pages/issues/1#issuecomment-623202206
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There's no breaking changes in this release (just some changes to default behaviour that don't look like they affect us), so this is mainly just to keep us from falling behind.

One new feature looks like it could be interesting for us, though - you can now make `zola serve` watch additional folders as well as the built-in ones. This could potentially help make the workflow a little less awkward for #378.