### PR TITLE
Remove outdated links from the homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -55,8 +55,14 @@
                 - there's a #games-and-graphics channel on the <a href="https://bit.ly/rust-community">Rust Community server</a>,
                 as well as a dedicated <a href="https://discord.gg/yNtPTb2">Game Development in Rust server</a>.
             </p>
-            <p>Many libraries have their own lively Gitter chats, which you can find in their descriptions.</p>
-            <p>Also see the <a href="https://www.reddit.com/r/rust_gamedev"><i class="icon reddit alien small"></i>subreddit</a>.</p>
+            <p>
+                Many libraries also have their own lively Gitter chats, which you can find in their descriptions.
+            </p>
+            <p>For news and updates, check out the <a href="https://www.reddit.com/r/rust_gamedev"><i class="icon reddit alien small"></i>subreddit</a>,
+                the community <a href="https://bsky.app/profile/gamedev.rs">Bluesky</a> and
+                <a href="https://mastodon.gamedev.place/@rust_gamedev">Mastodon</a> accounts, or the <a href="https://gamedev.rs/"><i class="icon newspaper small"></i>monthly newsletter</a>
+                (currently on pause).
+            </p>
         </div>
     </div>
 </section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,18 +34,17 @@
         </p>
         <p>
             If you haven't learned Rust yet, maybe take a look at <a href="#resources"><i class="icon list small"></i>Resources</a>
-            first. If you are already proficient with Rust you might want to start with <a href="#ecosystem"><i class="icon grid layout small"></i>Ecosystem</a>,
-            <a href="#news"><i class="icon newspaper small"></i>News</a>
-            or <a href="#chat"><i class="icon chat small"></i>Chat</a>.
+            first. If you are already proficient with Rust, you might want to start with <a href="#ecosystem"><i class="icon grid layout small"></i>Ecosystem</a> or
+            <a href="#community"><i class="icon users small"></i>Community</a>.
         </p>
     </div>
 </section>
 
 <section>
     <h3 class="ui horizontal divider small header">
-        <a href="#chat" id="chat">
-            <i class="chat icon big"></i>
-            Chat
+        <a href="#community" id="community">
+            <i class="users icon big"></i>
+            Community
         </a>
     </h3>
 
@@ -56,29 +55,8 @@
                 - there's a #games-and-graphics channel on the <a href="https://bit.ly/rust-community">Rust Community server</a>,
                 as well as a dedicated <a href="https://discord.gg/yNtPTb2">Game Development in Rust server</a>.
             </p>
-            <p>Many libraries have their own lively gitter chats, which you can find in their descriptions.</p>
+            <p>Many libraries have their own lively Gitter chats, which you can find in their descriptions.</p>
             <p>Also see the <a href="https://www.reddit.com/r/rust_gamedev"><i class="icon reddit alien small"></i>subreddit</a>.</p>
-        </div>
-    </div>
-</section>
-
-<section>
-    <h3 class="ui horizontal divider small header">
-        <a href="#news" id="news">
-            <i class="newspaper icon big"></i>
-            News
-        </a>
-    </h3>
-
-    <div class="ui vertical stripe">
-        <div class="ui text container">
-            <p>
-                The latest Rust gamedev news is available at:
-                the <a href="https://www.reddit.com/r/rust_gamedev"><i class="icon reddit alien small"></i>subreddit</a>,
-                the monthly  <a href="https://rust-gamedev.github.io/"><i class="icon newspaper small"></i>newsletter</a>,
-                the <a href="https://rustgamedev.com"><i class="icon headphones small"></i>podcast</a>,
-                and the <a href="https://twitter.com/rust_gamedev"><i class="icon twitter small"></i>@rust_gamedev</a> Twitter feed.
-            </p>
         </div>
     </div>
 </section>

--- a/templates/master.html
+++ b/templates/master.html
@@ -33,7 +33,7 @@
     <!-- Sidebar Menu -->
     <div class="ui vertical inverted sidebar menu">
         <a class="item" href="/">Home</a>
-        <a class="item" href="/#chat">Chat</a>
+        <a class="item" href="/#community">Community</a>
         <a class="item" href="/#ecosystem">Ecosystem</a>
         <a class="item" href="/#games">Games</a>
         <a class="item" href="/#curators">Curators</a>
@@ -54,10 +54,7 @@
                         <a class="item" href="/">Home</a>
                     </li>
                     <li>
-                        <a class="item" href="/#chat">Chat</a>
-                    </li>
-                    <li>
-                        <a class="item" href="/#news">News</a>
+                        <a class="item" href="/#community">Community</a>
                     </li>
                     <li>
                         <a class="item" href="/#ecosystem">Ecosystem</a>


### PR DESCRIPTION
Someone on Reddit made a good point that there's currently a lot of space on the homepage taken up by links to stuff that is no longer being updated:

* Newsletter: last post in July 2024.
* Podcast: last episode in June 2022.
* Twitter: last post in July 2024, migrated to Mastodon and Bluesky after that.

I think this gives a bit of a bad impression (the ecosystem is still super active, just not in those places), so I think it would be a good idea to remove these. If any of them start getting updates again, we can easily add them back in.

This left the subreddit as the only remaining link in the 'News' section. There's already a link to this under 'Chat', so I took the opportunity to consolidate those two sections into a single 'Community' block:

![image](https://github.com/user-attachments/assets/048936a2-e955-4b7f-be63-44d3a74790eb)

Thoughts?

---

cc @ozkriff: would you like me to add links to rust_gamedev on Mastodon and/or Bluesky? Happy to do that if so, just thought I should ask first 🙂 