### PR TITLE
Adding the 'lotus_engine' crate on the engines section

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -790,6 +790,12 @@ source = "crates"
 categories = ["physics"]
 
 [[items]]
+name = "lotus_engine"
+source = "crates"
+repository_url = "https://github.com/zenialexandre/lotus"
+categories = ["engines"]
+
+[[items]]
 name = "luajit"
 source = "crates"
 categories = ["scripting"]


### PR DESCRIPTION
feat: adding lotus_engine crate to the "engines" section