### PR TITLE
Remove rendology

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -1221,11 +1221,6 @@ categories = ["3drendering"]
 archived = true
 
 [[items]]
-name = "rendology"
-source = "crates"
-categories = ["3drendering"]
-
-[[items]]
 name = "rendy"
 source = "crates"
 categories = ["3drendering"]


### PR DESCRIPTION
Generally, we would archive crates rather than remove them entirely - but in this case, the crate has been entirely deleted from Crates.io, so we can no longer fetch the details for it (which is breaking the build).