### PR TITLE
Add crate: asset-importer

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -74,6 +74,11 @@ categories = ["3drendering"]
 gitter_url = "https://gitter.im/MaikKlein/ash"
 
 [[items]]
+name = "asset-importer"
+source = "crates"
+categories = ["3dformatloaders"]
+
+[[items]]
 name = "assets_manager"
 source = "crates"
 categories = ["tools"]


### PR DESCRIPTION
Adds the [asset-importer](https://github.com/Latias94/asset-importer) crate to the 3dformatloaders category