### PR TITLE
Add amble_engine and amble_script to data.toml

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -23,8 +23,8 @@ source = "crates"
 categories = ["audio"]
 
 [[items]]
-name = "amble_engine" 
-description = "Fully data-driven text adventure / I.F. game and scripting engine." 
+name = "amble_engine"
+description = "Fully data-driven text adventure / I.F. game and scripting engine."
 categories = ["engines"]
 crate_url = "https://crates.io/crates/amble_engine"
 repository_url = "https://github.com/pygmy-twylyte/amble"


### PR DESCRIPTION
Added two separate entries for Amble:
- **amble_engine**: the actual game engine / content loader and the playable demo game data
- **amble_script**: the DSL / compiler / linter -- not technically necessary to make games in amble_engine (content can be written directly in TOML)  but makes it **far** easier to create complex scripts / interactions / puzzle chains / etc.

I haven't included one other related repo, **zed-amble-ext** -- a Zed editor extension for authoring Amble content with full syntax highlighting / references / autocomplete / diagnostics etc.  Not sure if that fits any of your categories since it is editor-specific (though the supporting **tree-sitter-amble** repo could be used for other IDEs).