### PR TITLE
Add libnoise, macaw, roto, and yakui to data.toml

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -795,6 +795,11 @@ source = "crates"
 categories = ["audio"]
 
 [[items]]
+name = "libnoise"
+source = "crates"
+categories = ["tools"]
+
+[[items]]
 name = "libovr"
 source = "crates"
 categories = ["vr"]


### PR DESCRIPTION
- [libnoise](https://crates.io/crates/libnoise) is a new but excellent noise generation library that I'm currently using in my own game
- [macaw](https://crates.io/crates/macaw) is a math library built on top of glam and designed for games
- [roto](https://crates.io/crates/roto) is a strongly-typed, hot-reloadable, compiled scripting language
- [yakui](https://crates.io/crates/yakui) is a declarative UI library designed for games