### PR TITLE
add "verdant" crate

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -1686,6 +1686,11 @@ source = "crates"
 categories = ["math"]
 
 [[items]]
+name = "verdant"
+source = "crates"
+categories = ["2drendering", "windowing"]
+
+[[items]]
 name = "vk-mem"
 source = "crates"
 categories = ["3drendering"]


### PR DESCRIPTION
verdant is a rendering/windowing library i'm developing for rust
while it is a WIP, and the API is technically unstable, i'm fairly certain that the main API is unlikely to have drastic changes from now on (the main changes being new features, different arguments/return types, or code being moved to different modules, but like i don't expect *massive* changes)

it aims to make rendering easy and feel nice, it also makes window creation and use super simple