### PR TITLE
Add openusd crate

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -1727,6 +1727,11 @@ source = "crates"
 categories = ["3dformatloaders"]
 
 [[items]]
+name = "openusd"
+source = "crates"
+categories = ["3dformatloaders"]
+
+[[items]]
 name = "wavers"
 source = "crates"
 categories = ["audio"]

--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -1109,6 +1109,11 @@ source = "crates"
 categories = ["mesh", "3drendering"]
 
 [[items]]
+name = "openusd"
+source = "crates"
+categories = ["3dformatloaders"]
+
+[[items]]
 name = "openvr"
 source = "crates"
 categories = ["vr"]
@@ -1723,11 +1728,6 @@ categories = ["3drendering"]
 
 [[items]]
 name = "wavefront_obj"
-source = "crates"
-categories = ["3dformatloaders"]
-
-[[items]]
-name = "openusd"
 source = "crates"
 categories = ["3dformatloaders"]
 


### PR DESCRIPTION
Hello! This PR adds [`openusd`](https://crates.io/crates/openusd) ([github](https://github.com/mxpv/openusd)) crate - a Rust port of OpenUSD (an open-source 3D framework and interchange format developed by Pixar, popular in movies and gaining a lot of traction in gamedev recently). I've been working on it for couple of years now and would appreciate if you could add it the list.