### PR TITLE
Add Elura to networking

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -406,6 +406,11 @@ homepage_url = "https://www.ellie-lang.org/"
 gitter_url = "https://gitter.im/ellie-lang/community"
 
 [[items]]
+name = "elura"
+source = "crates"
+categories = ["networking"]
+
+[[items]]
 name = "EmbarkStudios/kajiya"
 source = "github"
 categories = ["3drendering"]


### PR DESCRIPTION
Adds [Elura](https://github.com/Arion-Dsh/elura) to the Networking ecosystem.

Elura is an open-source, modular Rust framework for authoritative realtime gameplay and extensible online game services. It is published on crates.io and provides transport, rooms, fixed-step simulation, AOI, replication, prediction, and lag-compensation building blocks.