### PR TITLE
Add renew to the ecosystem list

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -1319,6 +1319,14 @@ source = "crates"
 categories = ["networking"]
 
 [[items]]
+name = "renew-engine/renew"
+source = "github"
+description = "Deterministic, code-first game engine: fixed-timestep simulation in fixed point, Vulkan rendering, and a command-line face on every capability."
+categories = ["engines"]
+repository_url = "https://github.com/renew-engine/renew"
+homepage_url = "https://renew-engine.github.io/renew/"
+
+[[items]]
 name = "rhachis"
 source = "crates"
 categories = ["engines"]

--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -1321,7 +1321,7 @@ categories = ["networking"]
 [[items]]
 name = "renew-engine/renew"
 source = "github"
-description = "Deterministic, code-first game engine: fixed-timestep simulation in fixed point, Vulkan rendering, and a command-line face on every capability."
+description = "Deterministic, code-first game engine, published as the renew-* crates: bit-reproducible fixed-timestep simulation in fixed point, Vulkan rendering, and a command-line face on every capability."
 categories = ["engines"]
 repository_url = "https://github.com/renew-engine/renew"
 homepage_url = "https://renew-engine.github.io/renew/"


### PR DESCRIPTION
Adds [renew](https://github.com/renew-engine/renew) under `engines`.

renew is a game engine in Rust whose simulation core is bit-deterministic by
construction: a fixed timestep over integer nanoseconds, arithmetic in Q47.16
fixed point, no wall-clock reads, no unseeded randomness, and component storage
with a defined iteration order. Rendering goes through an internal RHI backed by
Vulkan via `ash`. Every capability is a library with a command-line face that
emits schema-versioned JSON.

It is 27 crates, five of them core; the rest are optional and removable, with CI
building and testing one configuration per removed crate. Apache-2.0.

- Crates: published as `renew-*`, currently 0.1.1 ([renew-frame](https://crates.io/crates/renew-frame), [renew-fixed](https://crates.io/crates/renew-fixed), [renew-ecs](https://crates.io/crates/renew-ecs), and 24 more)
- Documentation: https://docs.rs/renew-frame
- Release: https://github.com/renew-engine/renew/releases/tag/v0.1.1

Listed with `source = "github"` rather than `source = "crates"` because there is
no single umbrella crate: the engine is 27 crates under the `renew-` prefix, and
the bare `renew` name on crates.io belongs to an unrelated project. Happy to
switch this to a `crates` entry pointing at whichever crate you would consider
representative, if that fits the list better.

It is in early development (pre-0.1 in maturity terms, with no module yet at
`stable`) and the entry does not claim otherwise. Equally happy to hold this
until it is further along.