### PR TITLE
Add Floptle to engines

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -494,6 +494,13 @@ source = "crates"
 categories = ["ecs"]
 
 [[items]]
+name = "Floptle"
+description = "A game engine for carvable worlds: terrain is a volumetric SDF, so whole planets are diggable at runtime. Built-in editor, Lua scripting, rollback netcode, and in-editor tutorials that check your progress."
+categories = ["engines"]
+repository_url = "https://github.com/Fopull-LLC/Floptle"
+homepage_url = "https://fopull.com/floptle"
+
+[[items]]
 name = "fmod"
 source = "crates"
 categories = ["audio"]


### PR DESCRIPTION
Adds [Floptle](https://github.com/Fopull-LLC/Floptle), a free and open-source (MIT OR Apache-2.0) game engine written in Rust (wgpu, egui, mlua/LuaJIT).

**Terrain.** The signature feature: terrain is a volumetric signed-distance field rather than a heightmap, so caves, overhangs, and whole spherical planets are first-class — and all of it is carvable at runtime, with edits persisting through saves. Shadows and AO come off the distance field itself. There's also a retro mode that renders the full frame (post-processing included) at low internal resolution and upscales, for a PS1/N64 look on modern lighting.

**Multiplayer is built into the engine**, not a plugin — one netcode with three replication modes chosen per node:
- *Server authority* (default): the host simulates, clients render behind interp delay; cheat-proof, zero script requirements.
- *Predicted*: owner-side prediction with server reconciliation, plus `net.rewind` lag compensation for hit judgment.
- *Rollback* (GGPO-style): every peer re-simulates every tick from the session's input log — fixed host-set input delay (never adaptive), bounded resim depth that degrades to slowdown instead of teleporting, and mandatory periodic state checksums so cross-platform float divergence is caught instead of silently desyncing. Built on the engine's fixed-timestep deterministic sim, and being hardened against a fighting game built on the engine.

Supporting that: an in-editor network harness (host + join a local client in one process, with latency/packet-loss sliders), five-letter lobby codes through a small stateless relay anyone can self-host (`cargo run -p floptle-relay`, QUIC/UDP), direct LAN connect, and replays that are kilobytes because inputs + seed *are* the match — a desync that reproduces in a replay is debuggable offline.

**The rest:** built-in editor with play-in-editor and prefabs, Lua scripting with bundled VSCode autocomplete, a text + node-graph shader language (.flsl) with its own IR, timeline particles, skeletal animation from glTF, spatial audio, rigidbody physics with SDF colliders and gravity volumes, and in-editor follow-along tutorials where each step verifies itself against the actual project state. Docs are published with each release ([online mirror](https://fopull.com/floptle/docs), 85 pages, including ADRs on the rollback and determinism decisions).

Actively developed with frequent releases ([release history](https://fopull.com/floptle/releases)). Windows/macOS/Linux.
