### PR TITLE
Add Renzora Engine to the engines category

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -1334,6 +1334,13 @@ repository_url = "https://github.com/renew-engine/renew"
 homepage_url = "https://renew-engine.github.io/renew/"
 
 [[items]]
+name = "Renzora Engine"
+description = "A feature packed 2D/3D game engine and scene editor using Bevy"
+categories = ["engines"]
+repository_url = "https://github.com/renzora/engine"
+homepage_url = "https://renzora.com"
+
+[[items]]
 name = "rhachis"
 source = "crates"
 categories = ["engines"]


### PR DESCRIPTION
A 2D/3D game engine and scene editor built on Bevy 0.19.1. Ships as a single binary that runs as the editor when the editor bundle is beside it and as the game when it isn't, with Lua and Rust scripting and a C-ABI plugin system.

https://github.com/renzora/engine