### PR TITLE
Add micromegas to ecosystem tools

### DIFF
--- a/content/ecosystem/data.toml
+++ b/content/ecosystem/data.toml
@@ -934,6 +934,12 @@ source = "crates"
 categories = ["physics"]
 
 [[items]]
+name = "micromegas"
+source = "crates"
+categories = ["tools"]
+homepage_url = "https://micromegas.info/"
+
+[[items]]
 name = "minifb"
 source = "crates"
 categories = ["windowing"]


### PR DESCRIPTION
Adds [micromegas](https://github.com/madesroches/micromegas) to the Tools category.

Micromegas is a unified observability platform for logs, metrics and traces, built for high-volume environments including game engines (Rust and Unreal Engine instrumentation). It provides SQL analytics over the collected telemetry via Apache DataFusion/FlightSQL.
